### PR TITLE
feat(copilot): Copilot SDK Integration — Session Management + Agent Invocation

### DIFF
--- a/craig/package-lock.json
+++ b/craig/package-lock.json
@@ -8,7 +8,7 @@
       "name": "craig",
       "version": "0.1.0",
       "dependencies": {
-        "@octokit/rest": "^22.0.1",
+        "@github/copilot-sdk": "^0.1.32",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
       },
@@ -463,167 +463,139 @@
         "node": ">=18"
       }
     },
+    "node_modules/@github/copilot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.5.tgz",
+      "integrity": "sha512-lQGN1/qw7gJRT+lSW1U79Ltrf9rkF6UP8FcEb0hGEf9hq0K8/MaulzK+iDtH/gwXYweFXID29E3QlwSqbdsHqQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.5",
+        "@github/copilot-darwin-x64": "1.0.5",
+        "@github/copilot-linux-arm64": "1.0.5",
+        "@github/copilot-linux-x64": "1.0.5",
+        "@github/copilot-win32-arm64": "1.0.5",
+        "@github/copilot-win32-x64": "1.0.5"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.5.tgz",
+      "integrity": "sha512-XBwo8t5higPXzCvXVYkADImixt9k8P2XsflWup2b86x9KtcssYTcfEWWIg42AOCe8J/OJRJN2MMTQuWt5aeK9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.5.tgz",
+      "integrity": "sha512-zUlMEKct5oPk/ImnYKz+fUjI9xfIwRE2/WI8BrpuDDe16aFDW2Co/6WFFr5rgYcXoGX2Jm8HT563UUxaFbnnOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.5.tgz",
+      "integrity": "sha512-Rp5Key6IBcm00K3+yc8rga3IXaJKN7mwYtP/mpkCKaJJp7izpJK7Z7Dr1slb63Z3yCAyPwMeYlE+adFCwlnYUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.5.tgz",
+      "integrity": "sha512-ZEKOi57SUo3Ds2ZeYkIkHJ9MJA0Im1i04i0vdAPKH5Xibb2AC6I2EHO2dU/MWwqIeXoK5QDRh0r0Gs+BkHA/dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.32.tgz",
+      "integrity": "sha512-mPWM0fw1Gqc/SW8nl45K8abrFH+92fO7y6tRtRl5imjS5hGapLf/dkX5WDrgPtlsflD0c41lFXVUri5NVJwtoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.2",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.5.tgz",
+      "integrity": "sha512-pkhuKJZ1AcRAkVS2OO4BEBfMovGSuGWem4isBq+cgRDtuXRfRiZuc88Z9WcrtDCCwpdLx9rSYPVSWQG5fvupPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.5.tgz",
+      "integrity": "sha512-x6PWG80uCuCI+IgCLD1fnBJtfuf9nMBzJwOcMlFwjRtHduV/V9OOW3c89ooGwh/lRhCatAP5GxZGTyC7AJR3kQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
-        "json-with-bigint": "^3.5.3",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1135,12 +1107,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1275,22 +1241,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1329,12 +1279,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-with-bigint": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
-      "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -1617,12 +1561,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC"
-    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -1792,6 +1730,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/why-is-node-running": {

--- a/craig/package.json
+++ b/craig/package.json
@@ -20,7 +20,7 @@
     "vitest": "^3.1.0"
   },
   "dependencies": {
-    "@octokit/rest": "^22.0.1",
+    "@github/copilot-sdk": "^0.1.32",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"
   }

--- a/craig/src/copilot/__tests__/copilot.adapter.test.ts
+++ b/craig/src/copilot/__tests__/copilot.adapter.test.ts
@@ -11,12 +11,31 @@
  * - AC5: Model selection
  * - Edge cases: empty output, concurrent invocations, context concatenation, error handling
  *
+ * Regression tests for PR #21 security/quality findings:
+ * - FIX-1: Scoped permission handler (replaces approveAll)
+ * - FIX-2: Input sanitization (prompt injection prevention)
+ * - FIX-3: Runtime agent name validation
+ * - FIX-4: Typed error wiring (CopilotSessionError, CopilotTimeoutError, CopilotUnavailableError)
+ * - FIX-5: Discriminated union InvokeResult
+ * - FIX-6: Factory function createCopilotAdapter
+ *
  * All SDK interactions are mocked — no real API calls.
  */
 
 import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
-import { CopilotAdapter } from "../copilot.adapter.js";
-import type { InvokeParams, InvokeResult } from "../copilot.types.js";
+import {
+  CopilotAdapter,
+  createCopilotAdapter,
+  createScopedPermissionHandler,
+  sanitizeInput,
+} from "../copilot.adapter.js";
+import type {
+  InvokeParams,
+  InvokeResult,
+  InvokeSuccess,
+  InvokeFailure,
+} from "../copilot.types.js";
+import { GUARDIAN_AGENTS, isGuardianAgent } from "../copilot.types.js";
 import {
   CopilotSessionError,
   CopilotTimeoutError,
@@ -296,7 +315,7 @@ describe("CopilotAdapter", () => {
       const result = await adapter.invoke(makeParams());
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("Second failure");
+      expect(result.error).toContain("Session creation failed");
       expect(mockCreateSession).toHaveBeenCalledTimes(2);
     });
 
@@ -424,11 +443,443 @@ describe("CopilotAdapter", () => {
       expect(sessionConfig).toBeDefined();
     });
 
-    it("should set onPermissionRequest to approve all", async () => {
+    it("should set onPermissionRequest to scoped handler (not approveAll)", async () => {
       await adapter.invoke(makeParams());
 
       const sessionConfig = mockCreateSession.mock.calls[0]![0];
       expect(sessionConfig.onPermissionRequest).toBeDefined();
+      expect(typeof sessionConfig.onPermissionRequest).toBe("function");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-1: Scoped Permission Handler (CRITICAL — replaces approveAll)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-1: Scoped permission handler", () => {
+    it("should allow read-kind permission requests", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "read", toolCallId: "t1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should allow safe shell commands (git diff)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "git diff HEAD~1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should allow safe shell commands (git log)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "git log --oneline -5" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should allow safe shell commands (cat)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "cat src/index.ts" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should allow safe shell commands (ls)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "ls -la src/" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should deny write-kind permission requests", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "write", toolCallId: "t1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny url-kind permission requests", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "url", toolCallId: "t1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny mcp-kind permission requests", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "mcp", toolCallId: "t1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny custom-tool-kind permission requests", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "custom-tool", toolCallId: "t1" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny dangerous shell commands (rm)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "rm -rf /" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny dangerous shell commands (curl)", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "curl https://evil.com" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should deny shell without command field", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell" },
+        { sessionId: "s1" },
+      );
+      expect(result).toHaveProperty("kind", "denied-by-rules");
+    });
+
+    it("should trim leading whitespace before checking command prefix", () => {
+      const handler = createScopedPermissionHandler();
+      const result = handler(
+        { kind: "shell", command: "  git diff HEAD" },
+        { sessionId: "s1" },
+      );
+      expect(result).toEqual({ kind: "approved" });
+    });
+
+    it("should pass scoped handler to createSession (not approveAll)", async () => {
+      await adapter.invoke(makeParams());
+
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      const handler = sessionConfig.onPermissionRequest;
+
+      // Verify it's our scoped handler — denies write
+      const writeResult = handler(
+        { kind: "write" },
+        { sessionId: "s1" },
+      );
+      expect(writeResult).toHaveProperty("kind", "denied-by-rules");
+
+      // But allows read
+      const readResult = handler(
+        { kind: "read" },
+        { sessionId: "s1" },
+      );
+      expect(readResult).toEqual({ kind: "approved" });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-2: Input Sanitization (HIGH — prompt injection prevention)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-2: Input sanitization", () => {
+    it("should strip null bytes from prompt", () => {
+      const result = sanitizeInput("hello\x00world");
+      expect(result).toBe("helloworld");
+    });
+
+    it("should strip control characters from prompt", () => {
+      const result = sanitizeInput("hello\x01\x02\x03world");
+      expect(result).toBe("helloworld");
+    });
+
+    it("should preserve tabs in prompt", () => {
+      const result = sanitizeInput("hello\tworld");
+      expect(result).toBe("hello\tworld");
+    });
+
+    it("should preserve newlines in prompt", () => {
+      const result = sanitizeInput("hello\nworld");
+      expect(result).toBe("hello\nworld");
+    });
+
+    it("should preserve carriage returns in prompt", () => {
+      const result = sanitizeInput("hello\rworld");
+      expect(result).toBe("hello\rworld");
+    });
+
+    it("should strip DEL character", () => {
+      const result = sanitizeInput("hello\x7Fworld");
+      expect(result).toBe("helloworld");
+    });
+
+    it("should strip escape sequences used for terminal injection", () => {
+      const result = sanitizeInput("hello\x1B[31mred\x1B[0mworld");
+      expect(result).toBe("hello[31mred[0mworld");
+    });
+
+    it("should wrap context in structural delimiters", async () => {
+      const context = "--- a/file.ts\n+++ b/file.ts";
+      await adapter.invoke(makeParams({ context }));
+
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain("<context>");
+      expect(messageOptions.prompt).toContain("</context>");
+      expect(messageOptions.prompt).toContain(context);
+    });
+
+    it("should sanitize context content before wrapping in delimiters", async () => {
+      const context = "safe content\x00with\x01null bytes";
+      await adapter.invoke(makeParams({ context }));
+
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain("safe contentwith");
+      expect(messageOptions.prompt).not.toContain("\x00");
+      expect(messageOptions.prompt).not.toContain("\x01");
+    });
+
+    it("should sanitize prompt text", async () => {
+      const prompt = "Review this\x00 diff";
+      await adapter.invoke(makeParams({ prompt }));
+
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain("Review this diff");
+      expect(messageOptions.prompt).not.toContain("\x00");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-3: Runtime Agent Name Validation (HIGH — injection prevention)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-3: Runtime agent name validation", () => {
+    it("should contain all four guardian agent names", () => {
+      expect(GUARDIAN_AGENTS.has("security-guardian")).toBe(true);
+      expect(GUARDIAN_AGENTS.has("code-review-guardian")).toBe(true);
+      expect(GUARDIAN_AGENTS.has("qa-guardian")).toBe(true);
+      expect(GUARDIAN_AGENTS.has("po-guardian")).toBe(true);
+    });
+
+    it("should reject invalid agent names via isGuardianAgent", () => {
+      expect(isGuardianAgent("evil-agent")).toBe(false);
+      expect(isGuardianAgent("")).toBe(false);
+      expect(isGuardianAgent("security-guardian; rm -rf /")).toBe(false);
+    });
+
+    it("should accept valid agent names via isGuardianAgent", () => {
+      expect(isGuardianAgent("security-guardian")).toBe(true);
+      expect(isGuardianAgent("qa-guardian")).toBe(true);
+    });
+
+    it("should return failure for invalid agent name in invoke", async () => {
+      const result = await adapter.invoke(
+        makeParams({ agent: "evil-agent" as any }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Invalid agent");
+      expect(result.error).toContain("evil-agent");
+    });
+
+    it("should not create a session for invalid agent name", async () => {
+      await adapter.invoke(
+        makeParams({ agent: "fake-agent" as any }),
+      );
+
+      expect(mockCreateSession).not.toHaveBeenCalled();
+    });
+
+    it("should list allowed agents in the error message", async () => {
+      const result = await adapter.invoke(
+        makeParams({ agent: "bad" as any }),
+      );
+
+      expect(result.error).toContain("security-guardian");
+      expect(result.error).toContain("code-review-guardian");
+      expect(result.error).toContain("qa-guardian");
+      expect(result.error).toContain("po-guardian");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-4: Typed Error Wiring (HIGH — dead error types now alive)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-4: Typed error wiring", () => {
+    it("should wrap session creation failure in CopilotSessionError", async () => {
+      mockCreateSession
+        .mockRejectedValueOnce(new Error("Connection refused"))
+        .mockRejectedValueOnce(new Error("Connection refused"));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Session creation failed");
+    });
+
+    it("should classify timeout errors using CopilotTimeoutError message", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Request timeout exceeded"));
+
+      const result = await adapter.invoke(makeParams({ timeout: 60_000 }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Timeout after");
+      expect(result.error).toContain("60000");
+    });
+
+    it("should classify generic timeout strings (case-insensitive)", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("TIMEOUT waiting for response"));
+
+      const result = await adapter.invoke(makeParams({ timeout: 30_000 }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Timeout after 30000ms");
+    });
+
+    it("should use CopilotUnavailableError when not authenticated", async () => {
+      mockGetAuthStatus.mockResolvedValue({ isAuthenticated: false });
+
+      const available = await adapter.isAvailable();
+
+      expect(available).toBe(false);
+    });
+
+    it("should preserve original error as cause in CopilotSessionError", async () => {
+      const originalError = new Error("ECONNREFUSED");
+      mockCreateSession
+        .mockRejectedValueOnce(originalError)
+        .mockRejectedValueOnce(originalError);
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      // The error message comes from CopilotSessionError, not the raw original
+      expect(result.error).toContain("Session creation failed");
+    });
+
+    it("should not wrap non-timeout errors in CopilotTimeoutError", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Network error"));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Network error");
+      expect(result.error).not.toContain("Timeout after");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-5: Discriminated Union InvokeResult (HIGH — type safety)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-5: Discriminated union InvokeResult", () => {
+    it("should return InvokeSuccess with success: true and no error field", async () => {
+      mockSendAndWait.mockResolvedValue(
+        makeAssistantResponse("Report output"),
+      );
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // TypeScript narrows to InvokeSuccess — error field does not exist
+        expect(result.output).toBe("Report output");
+        expect(result.model_used).toBe("claude-sonnet-4.5");
+        expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+        expect("error" in result).toBe(false);
+      }
+    });
+
+    it("should return InvokeFailure with success: false and required error", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Boom"));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // TypeScript narrows to InvokeFailure — error is required string
+        expect(typeof result.error).toBe("string");
+        expect(result.error.length).toBeGreaterThan(0);
+        expect(result.output).toBe("");
+      }
+    });
+
+    it("should allow type narrowing via success discriminant", async () => {
+      const result = await adapter.invoke(makeParams());
+
+      // This tests that TypeScript narrows correctly at runtime
+      if (result.success) {
+        const success: InvokeSuccess = result;
+        expect(success.output).toBeDefined();
+      } else {
+        const failure: InvokeFailure = result;
+        expect(failure.error).toBeDefined();
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // FIX-6: Factory Function (HIGH — project pattern compliance)
+  // -----------------------------------------------------------------------
+
+  describe("FIX-6: Factory function createCopilotAdapter", () => {
+    it("should return a CopilotPort interface", () => {
+      const port = createCopilotAdapter(DEFAULT_OPTIONS);
+
+      expect(port).toBeDefined();
+      expect(typeof port.invoke).toBe("function");
+      expect(typeof port.isAvailable).toBe("function");
+    });
+
+    it("should create a functional adapter that can invoke", async () => {
+      const port = createCopilotAdapter(DEFAULT_OPTIONS);
+
+      const result = await port.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should create a functional adapter that checks availability", async () => {
+      mockPing.mockResolvedValue({ message: "pong", timestamp: Date.now() });
+      mockGetAuthStatus.mockResolvedValue({
+        isAuthenticated: true,
+        login: "testuser",
+      });
+
+      const port = createCopilotAdapter(DEFAULT_OPTIONS);
+
+      const available = await port.isAvailable();
+
+      expect(available).toBe(true);
+    });
+
+    it("should pass options to the underlying adapter", async () => {
+      const port = createCopilotAdapter({
+        defaultModel: "gpt-5.4",
+        guardiansPath: "/custom/path",
+      });
+
+      const result = await port.invoke(makeParams());
+
+      expect(result.model_used).toBe("gpt-5.4");
     });
   });
 });

--- a/craig/src/copilot/__tests__/copilot.adapter.test.ts
+++ b/craig/src/copilot/__tests__/copilot.adapter.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Copilot Adapter — Unit Tests
+ *
+ * TDD Red → Green → Refactor: These tests were written BEFORE the implementation.
+ *
+ * Test coverage maps to issue #5 acceptance criteria:
+ * - AC1: Invoke Security Guardian — success path
+ * - AC2: Handle timeout
+ * - AC3: Handle SDK unavailable
+ * - AC4: Retry on session failure
+ * - AC5: Model selection
+ * - Edge cases: empty output, concurrent invocations, context concatenation, error handling
+ *
+ * All SDK interactions are mocked — no real API calls.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { CopilotAdapter } from "../copilot.adapter.js";
+import type { InvokeParams, InvokeResult } from "../copilot.types.js";
+import {
+  CopilotSessionError,
+  CopilotTimeoutError,
+  CopilotUnavailableError,
+} from "../copilot.errors.js";
+
+// ---------------------------------------------------------------------------
+// SDK Mocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock the @github/copilot-sdk module.
+ * We create mock classes that mimic CopilotClient and CopilotSession behavior.
+ */
+const mockDisconnect = vi.fn().mockResolvedValue(undefined);
+const mockSendAndWait = vi.fn();
+const mockSetModel = vi.fn().mockResolvedValue(undefined);
+
+const mockSession = {
+  sessionId: "mock-session-123",
+  disconnect: mockDisconnect,
+  sendAndWait: mockSendAndWait,
+  setModel: mockSetModel,
+};
+
+const mockCreateSession = vi.fn().mockResolvedValue(mockSession);
+const mockDeleteSession = vi.fn().mockResolvedValue(undefined);
+const mockStart = vi.fn().mockResolvedValue(undefined);
+const mockStop = vi.fn().mockResolvedValue([]);
+const mockPing = vi.fn().mockResolvedValue({ message: "pong", timestamp: Date.now() });
+const mockGetAuthStatus = vi
+  .fn()
+  .mockResolvedValue({ isAuthenticated: true, login: "testuser" });
+
+vi.mock("@github/copilot-sdk", () => {
+  return {
+    CopilotClient: vi.fn().mockImplementation(() => ({
+      start: mockStart,
+      stop: mockStop,
+      createSession: mockCreateSession,
+      deleteSession: mockDeleteSession,
+      ping: mockPing,
+      getAuthStatus: mockGetAuthStatus,
+      getState: vi.fn().mockReturnValue("connected"),
+    })),
+    approveAll: vi.fn().mockReturnValue("allow"),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default config-like options for the adapter. */
+const DEFAULT_OPTIONS = {
+  defaultModel: "claude-sonnet-4.5",
+  guardiansPath: "~/.copilot/",
+};
+
+/** Build InvokeParams with defaults. */
+function makeParams(overrides: Partial<InvokeParams> = {}): InvokeParams {
+  return {
+    agent: "security-guardian",
+    prompt: "Review this diff for vulnerabilities",
+    ...overrides,
+  };
+}
+
+/** Simulate a successful assistant response from the SDK. */
+function makeAssistantResponse(content: string) {
+  return {
+    type: "assistant.message" as const,
+    data: { content },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CopilotAdapter", () => {
+  let adapter: CopilotAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new CopilotAdapter(DEFAULT_OPTIONS);
+
+    // Default: sendAndWait returns a Guardian report
+    mockSendAndWait.mockResolvedValue(
+      makeAssistantResponse("## Security Guardian Report\n\nNo issues found."),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // AC1: Invoke Security Guardian — success path
+  // -----------------------------------------------------------------------
+
+  describe("AC1: Invoke Security Guardian", () => {
+    it("should return success with guardian output", async () => {
+      const expectedOutput = "## Security Guardian Report\n\n3 findings detected.";
+      mockSendAndWait.mockResolvedValue(makeAssistantResponse(expectedOutput));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe(expectedOutput);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("should include duration_ms in result", async () => {
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(typeof result.duration_ms).toBe("number");
+    });
+
+    it("should include model_used in result", async () => {
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.model_used).toBe("claude-sonnet-4.5");
+    });
+
+    it("should create a session with the correct agent configuration", async () => {
+      await adapter.invoke(makeParams({ agent: "security-guardian" }));
+
+      expect(mockCreateSession).toHaveBeenCalledTimes(1);
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      expect(sessionConfig.model).toBe("claude-sonnet-4.5");
+    });
+
+    it("should send prompt to the session", async () => {
+      await adapter.invoke(
+        makeParams({ prompt: "Review this diff for vulnerabilities" }),
+      );
+
+      expect(mockSendAndWait).toHaveBeenCalledTimes(1);
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain("Review this diff for vulnerabilities");
+    });
+
+    it("should disconnect session after invocation", async () => {
+      await adapter.invoke(makeParams());
+
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("should stop the client after invocation", async () => {
+      await adapter.invoke(makeParams());
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+
+    it("should include agent name in the prompt", async () => {
+      await adapter.invoke(makeParams({ agent: "code-review-guardian" }));
+
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain("code-review-guardian");
+    });
+
+    it("should include context in the prompt when provided", async () => {
+      const diffText = "--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new";
+      await adapter.invoke(makeParams({ context: diffText }));
+
+      const messageOptions = mockSendAndWait.mock.calls[0]![0];
+      expect(messageOptions.prompt).toContain(diffText);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC2: Handle timeout
+  // -----------------------------------------------------------------------
+
+  describe("AC2: Handle timeout", () => {
+    it("should return failure with timeout error message", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Timeout"));
+
+      const result = await adapter.invoke(makeParams({ timeout: 1000 }));
+
+      expect(result.success).toBe(false);
+      expect(result.output).toBe("");
+      expect(result.error).toBeDefined();
+    });
+
+    it("should pass timeout to sendAndWait", async () => {
+      await adapter.invoke(makeParams({ timeout: 120_000 }));
+
+      const timeout = mockSendAndWait.mock.calls[0]![1];
+      expect(timeout).toBe(120_000);
+    });
+
+    it("should use default 5-minute timeout when not specified", async () => {
+      await adapter.invoke(makeParams());
+
+      const timeout = mockSendAndWait.mock.calls[0]![1];
+      expect(timeout).toBe(300_000);
+    });
+
+    it("should still disconnect session on timeout", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Timeout"));
+
+      await adapter.invoke(makeParams({ timeout: 1000 }));
+
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("should still stop client on timeout", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Timeout"));
+
+      await adapter.invoke(makeParams({ timeout: 1000 }));
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC3: Handle SDK unavailable
+  // -----------------------------------------------------------------------
+
+  describe("AC3: Handle SDK unavailable", () => {
+    it("should return false when ping fails", async () => {
+      mockPing.mockRejectedValue(new Error("Connection refused"));
+
+      const available = await adapter.isAvailable();
+
+      expect(available).toBe(false);
+    });
+
+    it("should return true when ping succeeds and auth is OK", async () => {
+      mockPing.mockResolvedValue({ message: "pong", timestamp: Date.now() });
+      mockGetAuthStatus.mockResolvedValue({
+        isAuthenticated: true,
+        login: "testuser",
+      });
+
+      const available = await adapter.isAvailable();
+
+      expect(available).toBe(true);
+    });
+
+    it("should return false when auth check fails", async () => {
+      mockPing.mockResolvedValue({ message: "pong", timestamp: Date.now() });
+      mockGetAuthStatus.mockRejectedValue(new Error("Not authenticated"));
+
+      const available = await adapter.isAvailable();
+
+      expect(available).toBe(false);
+    });
+
+    it("should stop client after availability check", async () => {
+      await adapter.isAvailable();
+
+      expect(mockStop).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC4: Retry on session failure
+  // -----------------------------------------------------------------------
+
+  describe("AC4: Retry on session failure", () => {
+    it("should retry once when session creation fails", async () => {
+      mockCreateSession
+        .mockRejectedValueOnce(new Error("Session creation failed"))
+        .mockResolvedValueOnce(mockSession);
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return failure when both attempts fail", async () => {
+      mockCreateSession
+        .mockRejectedValueOnce(new Error("First failure"))
+        .mockRejectedValueOnce(new Error("Second failure"));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Second failure");
+      expect(mockCreateSession).toHaveBeenCalledTimes(2);
+    });
+
+    it("should still clean up client after retry failure", async () => {
+      mockCreateSession
+        .mockRejectedValueOnce(new Error("First failure"))
+        .mockRejectedValueOnce(new Error("Second failure"));
+
+      await adapter.invoke(makeParams());
+
+      expect(mockStop).toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC5: Model selection
+  // -----------------------------------------------------------------------
+
+  describe("AC5: Model selection", () => {
+    it("should use default model from config", async () => {
+      await adapter.invoke(makeParams());
+
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      expect(sessionConfig.model).toBe("claude-sonnet-4.5");
+    });
+
+    it("should use override model when specified in params", async () => {
+      await adapter.invoke(makeParams({ model: "claude-opus-4.6" }));
+
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      expect(sessionConfig.model).toBe("claude-opus-4.6");
+    });
+
+    it("should report model_used matching the override", async () => {
+      const result = await adapter.invoke(makeParams({ model: "gpt-5.4" }));
+
+      expect(result.model_used).toBe("gpt-5.4");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+
+  describe("Edge cases", () => {
+    it("should handle empty output from agent", async () => {
+      mockSendAndWait.mockResolvedValue(makeAssistantResponse(""));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("");
+    });
+
+    it("should handle undefined response from sendAndWait", async () => {
+      mockSendAndWait.mockResolvedValue(undefined);
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("");
+    });
+
+    it("should handle sendAndWait error as failure (not throw)", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Network error"));
+
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Network error");
+      expect(result.output).toBe("");
+    });
+
+    it("should disconnect session even when sendAndWait fails", async () => {
+      mockSendAndWait.mockRejectedValue(new Error("Boom"));
+
+      await adapter.invoke(makeParams());
+
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle disconnect failure gracefully", async () => {
+      mockDisconnect.mockRejectedValueOnce(new Error("Disconnect failed"));
+
+      // Should not throw
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle stop failure gracefully", async () => {
+      mockStop.mockResolvedValueOnce([new Error("Stop error")]);
+
+      // Should not throw
+      const result = await adapter.invoke(makeParams());
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept all guardian agent types", async () => {
+      const agents = [
+        "security-guardian",
+        "code-review-guardian",
+        "qa-guardian",
+        "po-guardian",
+      ] as const;
+
+      for (const agent of agents) {
+        vi.clearAllMocks();
+        mockSendAndWait.mockResolvedValue(
+          makeAssistantResponse(`## ${agent} Report`),
+        );
+
+        const result = await adapter.invoke(makeParams({ agent }));
+        expect(result.success).toBe(true);
+        expect(result.output).toContain(agent);
+      }
+    });
+
+    it("should configure session with guardiansPath as agent slug", async () => {
+      await adapter.invoke(makeParams({ agent: "security-guardian" }));
+
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      // Adapter should configure customAgents or include path info
+      expect(sessionConfig).toBeDefined();
+    });
+
+    it("should set onPermissionRequest to approve all", async () => {
+      await adapter.invoke(makeParams());
+
+      const sessionConfig = mockCreateSession.mock.calls[0]![0];
+      expect(sessionConfig.onPermissionRequest).toBeDefined();
+    });
+  });
+});

--- a/craig/src/copilot/copilot.adapter.ts
+++ b/craig/src/copilot/copilot.adapter.ts
@@ -1,0 +1,232 @@
+/**
+ * CopilotAdapter — SDK-based implementation of CopilotPort.
+ *
+ * Manages Copilot SDK sessions and invokes Guardian agents by name.
+ * Each invocation creates a fresh client + session, sends the prompt,
+ * captures the response, and cleans up.
+ *
+ * Design decisions:
+ * - One client + session per invocation — no shared state [CLEAN-CODE]
+ * - Retry once on session creation failure [AC4]
+ * - Never throws — returns InvokeResult with success: false [CLEAN-CODE]
+ * - Cleanup always runs (finally block) — prevents session leaks [CLEAN-CODE]
+ * - Prompt includes agent name as @-mention for Copilot routing [CUSTOM]
+ *
+ * @module copilot
+ */
+
+import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import type { CopilotPort } from "./copilot.port.js";
+import type { InvokeParams, InvokeResult } from "./copilot.types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default timeout for agent invocations: 5 minutes. */
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+/** Maximum number of session creation attempts (initial + retries). */
+const MAX_SESSION_ATTEMPTS = 2;
+
+// ---------------------------------------------------------------------------
+// Adapter Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the CopilotAdapter.
+ * Sourced from Craig's config (models.default, guardians.path).
+ */
+export interface CopilotAdapterOptions {
+  /** Default model to use for invocations. */
+  readonly defaultModel: string;
+
+  /** Path to Guardian agent definitions. */
+  readonly guardiansPath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * SDK-based adapter implementing CopilotPort.
+ *
+ * [HEXAGONAL] This is the outward-facing adapter. It depends on
+ * the @github/copilot-sdk concrete implementation. Consumers
+ * depend on CopilotPort, never on this class directly.
+ */
+export class CopilotAdapter implements CopilotPort {
+  private readonly options: CopilotAdapterOptions;
+
+  constructor(options: CopilotAdapterOptions) {
+    this.options = options;
+  }
+
+  /**
+   * Invoke a Guardian agent via Copilot SDK.
+   *
+   * Creates a fresh client + session, sends the agent-routed prompt,
+   * waits for the response, and cleans up. Retries once on session
+   * creation failure per AC4.
+   */
+  async invoke(params: InvokeParams): Promise<InvokeResult> {
+    const model = params.model ?? this.options.defaultModel;
+    const timeout = params.timeout ?? DEFAULT_TIMEOUT_MS;
+    const startTime = performance.now();
+
+    const client = new CopilotClient();
+    let session: Awaited<ReturnType<CopilotClient["createSession"]>> | undefined;
+
+    try {
+      // Create session with retry (AC4)
+      session = await this.createSessionWithRetry(client, model);
+
+      // Build and send prompt
+      const prompt = this.buildPrompt(params);
+      const response = await session.sendAndWait({ prompt }, timeout);
+
+      // Extract output
+      const output = this.extractOutput(response);
+      const duration_ms = Math.round(performance.now() - startTime);
+
+      return {
+        success: true,
+        output,
+        duration_ms,
+        model_used: model,
+      };
+    } catch (error: unknown) {
+      const duration_ms = Math.round(performance.now() - startTime);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        success: false,
+        output: "",
+        duration_ms,
+        model_used: model,
+        error: errorMessage,
+      };
+    } finally {
+      await this.cleanup(session, client);
+    }
+  }
+
+  /**
+   * Check whether Copilot SDK is available and authenticated.
+   *
+   * Creates a temporary client, pings the server, and checks auth status.
+   * Returns false on any failure — never throws.
+   */
+  async isAvailable(): Promise<boolean> {
+    const client = new CopilotClient();
+
+    try {
+      await client.start();
+      await client.ping();
+      const authStatus = await client.getAuthStatus();
+      return authStatus.isAuthenticated === true;
+    } catch {
+      return false;
+    } finally {
+      try {
+        await client.stop();
+      } catch {
+        // Cleanup failure is not a problem for availability check
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Create a session with one retry on failure.
+   *
+   * [AC4] If the first session creation fails, retries once
+   * with a fresh attempt. If both fail, throws the second error.
+   */
+  private async createSessionWithRetry(
+    client: CopilotClient,
+    model: string,
+  ): Promise<Awaited<ReturnType<CopilotClient["createSession"]>>> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < MAX_SESSION_ATTEMPTS; attempt++) {
+      try {
+        const session = await client.createSession({
+          model,
+          onPermissionRequest: approveAll,
+        });
+        return session;
+      } catch (error: unknown) {
+        lastError = error;
+      }
+    }
+
+    throw lastError;
+  }
+
+  /**
+   * Build the prompt string including agent routing and optional context.
+   *
+   * Format:
+   * ```
+   * @{agent-name} {prompt}
+   *
+   * Context:
+   * {context}
+   * ```
+   */
+  private buildPrompt(params: InvokeParams): string {
+    let prompt = `@${params.agent} ${params.prompt}`;
+
+    if (params.context) {
+      prompt += `\n\nContext:\n${params.context}`;
+    }
+
+    return prompt;
+  }
+
+  /**
+   * Extract text content from the SDK response.
+   *
+   * Handles undefined responses and missing content gracefully.
+   */
+  private extractOutput(
+    response: { type: string; data: { content: string } } | undefined,
+  ): string {
+    if (!response) {
+      return "";
+    }
+
+    return response.data?.content ?? "";
+  }
+
+  /**
+   * Clean up session and client resources.
+   *
+   * Always runs in the finally block. Swallows cleanup errors
+   * to avoid masking the original error.
+   */
+  private async cleanup(
+    session: Awaited<ReturnType<CopilotClient["createSession"]>> | undefined,
+    client: CopilotClient,
+  ): Promise<void> {
+    try {
+      if (session) {
+        await session.disconnect();
+      }
+    } catch {
+      // Swallow disconnect errors — cleanup should not mask original error
+    }
+
+    try {
+      await client.stop();
+    } catch {
+      // Swallow stop errors — cleanup should not mask original error
+    }
+  }
+}

--- a/craig/src/copilot/copilot.adapter.ts
+++ b/craig/src/copilot/copilot.adapter.ts
@@ -11,13 +11,23 @@
  * - Never throws — returns InvokeResult with success: false [CLEAN-CODE]
  * - Cleanup always runs (finally block) — prevents session leaks [CLEAN-CODE]
  * - Prompt includes agent name as @-mention for Copilot routing [CUSTOM]
+ * - Scoped permissions — only read + safe shell commands allowed [SECURITY]
+ * - Input sanitization — control chars stripped, context delimited [SECURITY]
+ * - Agent name validated at runtime against allowlist [SECURITY]
  *
  * @module copilot
  */
 
-import { CopilotClient, approveAll } from "@github/copilot-sdk";
+import { CopilotClient } from "@github/copilot-sdk";
+import type { PermissionHandler, PermissionRequest } from "@github/copilot-sdk";
 import type { CopilotPort } from "./copilot.port.js";
 import type { InvokeParams, InvokeResult } from "./copilot.types.js";
+import { GUARDIAN_AGENTS } from "./copilot.types.js";
+import {
+  CopilotSessionError,
+  CopilotTimeoutError,
+  CopilotUnavailableError,
+} from "./copilot.errors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -28,6 +38,95 @@ const DEFAULT_TIMEOUT_MS = 300_000;
 
 /** Maximum number of session creation attempts (initial + retries). */
 const MAX_SESSION_ATTEMPTS = 2;
+
+// ---------------------------------------------------------------------------
+// Scoped Permission Handler [SECURITY]
+// ---------------------------------------------------------------------------
+
+/**
+ * Permission kinds that are always safe (read-only operations).
+ * Maps to SDK tools: view, grep, glob.
+ */
+const ALLOWED_PERMISSION_KINDS: ReadonlySet<string> = new Set(["read"]);
+
+/**
+ * Safe shell command prefixes for read-only operations.
+ * Only commands that cannot modify the filesystem or exfiltrate data.
+ */
+const ALLOWED_SHELL_PREFIXES: readonly string[] = [
+  "git diff",
+  "git log",
+  "git show",
+  "git status",
+  "git branch",
+  "ls ",
+  "cat ",
+  "find ",
+  "head ",
+  "tail ",
+  "wc ",
+  "grep ",
+];
+
+/**
+ * Create a scoped permission handler that only allows safe operations.
+ *
+ * [SECURITY] Replaces `approveAll` which granted blanket permission
+ * to every tool request. This handler:
+ * - Allows read-only operations (view, grep, glob)
+ * - Allows shell commands matching safe prefixes (git diff, ls, cat, etc.)
+ * - Denies all write, URL, MCP, and custom-tool operations
+ *
+ * @returns A PermissionHandler that enforces the allowlist
+ */
+export function createScopedPermissionHandler(): PermissionHandler {
+  return (request: PermissionRequest) => {
+    if (ALLOWED_PERMISSION_KINDS.has(request.kind)) {
+      return { kind: "approved" as const };
+    }
+
+    if (request.kind === "shell") {
+      const rawCommand = request["command"];
+      const command =
+        typeof rawCommand === "string" ? rawCommand.trimStart() : "";
+
+      if (
+        ALLOWED_SHELL_PREFIXES.some((prefix) => command.startsWith(prefix))
+      ) {
+        return { kind: "approved" as const };
+      }
+    }
+
+    return {
+      kind: "denied-by-rules" as const,
+      rules: [
+        {
+          name: "craig-scoped-permissions",
+          description: `Denied: ${request.kind}`,
+        },
+      ],
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Input Sanitization [SECURITY]
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip control characters from user-provided input.
+ *
+ * [SECURITY] Removes null bytes and non-printable control characters
+ * that could be used for prompt injection or terminal escape attacks.
+ * Preserves tabs (\t), newlines (\n), and carriage returns (\r).
+ *
+ * @param input - Raw user input string
+ * @returns Sanitized string with control characters removed
+ */
+export function sanitizeInput(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+}
 
 // ---------------------------------------------------------------------------
 // Adapter Options
@@ -69,20 +168,36 @@ export class CopilotAdapter implements CopilotPort {
    * Creates a fresh client + session, sends the agent-routed prompt,
    * waits for the response, and cleans up. Retries once on session
    * creation failure per AC4.
+   *
+   * @throws Never — always returns InvokeResult, errors captured in result.error
    */
   async invoke(params: InvokeParams): Promise<InvokeResult> {
     const model = params.model ?? this.options.defaultModel;
     const timeout = params.timeout ?? DEFAULT_TIMEOUT_MS;
     const startTime = performance.now();
 
+    // [SECURITY] Validate agent name at runtime against allowlist
+    if (!GUARDIAN_AGENTS.has(params.agent)) {
+      const duration_ms = Math.round(performance.now() - startTime);
+      return {
+        success: false as const,
+        output: "",
+        duration_ms,
+        model_used: model,
+        error: `Invalid agent: "${params.agent}". Allowed: ${[...GUARDIAN_AGENTS].join(", ")}`,
+      };
+    }
+
     const client = new CopilotClient();
-    let session: Awaited<ReturnType<CopilotClient["createSession"]>> | undefined;
+    let session:
+      | Awaited<ReturnType<CopilotClient["createSession"]>>
+      | undefined;
 
     try {
       // Create session with retry (AC4)
       session = await this.createSessionWithRetry(client, model);
 
-      // Build and send prompt
+      // Build and send prompt (sanitized)
       const prompt = this.buildPrompt(params);
       const response = await session.sendAndWait({ prompt }, timeout);
 
@@ -91,18 +206,17 @@ export class CopilotAdapter implements CopilotPort {
       const duration_ms = Math.round(performance.now() - startTime);
 
       return {
-        success: true,
+        success: true as const,
         output,
         duration_ms,
         model_used: model,
       };
     } catch (error: unknown) {
       const duration_ms = Math.round(performance.now() - startTime);
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.classifyError(error, timeout);
 
       return {
-        success: false,
+        success: false as const,
         output: "",
         duration_ms,
         model_used: model,
@@ -126,7 +240,14 @@ export class CopilotAdapter implements CopilotPort {
       await client.start();
       await client.ping();
       const authStatus = await client.getAuthStatus();
-      return authStatus.isAuthenticated === true;
+
+      if (authStatus.isAuthenticated !== true) {
+        throw new CopilotUnavailableError(
+          "Copilot is not authenticated. Run 'gh auth login' to authenticate.",
+        );
+      }
+
+      return true;
     } catch {
       return false;
     } finally {
@@ -146,7 +267,8 @@ export class CopilotAdapter implements CopilotPort {
    * Create a session with one retry on failure.
    *
    * [AC4] If the first session creation fails, retries once
-   * with a fresh attempt. If both fail, throws the second error.
+   * with a fresh attempt. If both fail, throws CopilotSessionError
+   * wrapping the last error for precise error classification.
    */
   private async createSessionWithRetry(
     client: CopilotClient,
@@ -158,7 +280,7 @@ export class CopilotAdapter implements CopilotPort {
       try {
         const session = await client.createSession({
           model,
-          onPermissionRequest: approveAll,
+          onPermissionRequest: createScopedPermissionHandler(),
         });
         return session;
       } catch (error: unknown) {
@@ -166,28 +288,69 @@ export class CopilotAdapter implements CopilotPort {
       }
     }
 
-    throw lastError;
+    throw new CopilotSessionError(
+      "Session creation failed after retries",
+      { cause: lastError },
+    );
   }
 
   /**
    * Build the prompt string including agent routing and optional context.
    *
+   * [SECURITY] Sanitizes prompt and context to strip control characters.
+   * Wraps context in structural delimiters to prevent prompt injection.
+   *
    * Format:
    * ```
-   * @{agent-name} {prompt}
+   * @{agent-name} {sanitized-prompt}
    *
-   * Context:
-   * {context}
+   * <context>
+   * {sanitized-context}
+   * </context>
    * ```
    */
   private buildPrompt(params: InvokeParams): string {
-    let prompt = `@${params.agent} ${params.prompt}`;
+    const sanitizedPrompt = sanitizeInput(params.prompt);
+    let prompt = `@${params.agent} ${sanitizedPrompt}`;
 
     if (params.context) {
-      prompt += `\n\nContext:\n${params.context}`;
+      const sanitizedContext = sanitizeInput(params.context);
+      prompt += `\n\n<context>\n${sanitizedContext}\n</context>`;
     }
 
     return prompt;
+  }
+
+  /**
+   * Classify an error into the appropriate custom error type.
+   *
+   * [CLEAN-CODE] Maps generic SDK errors to domain-specific error types,
+   * providing consumers with actionable error messages.
+   *
+   * @returns A descriptive error message from the classified error
+   */
+  private classifyError(error: unknown, timeout: number): string {
+    // Already classified — use directly
+    if (error instanceof CopilotSessionError) {
+      return error.message;
+    }
+
+    if (error instanceof CopilotTimeoutError) {
+      return error.message;
+    }
+
+    if (error instanceof CopilotUnavailableError) {
+      return error.message;
+    }
+
+    // Detect timeout from SDK errors
+    const message = error instanceof Error ? error.message : String(error);
+    if (/timeout/i.test(message)) {
+      const timeoutError = new CopilotTimeoutError(timeout, { cause: error });
+      return timeoutError.message;
+    }
+
+    return message;
   }
 
   /**
@@ -212,7 +375,9 @@ export class CopilotAdapter implements CopilotPort {
    * to avoid masking the original error.
    */
   private async cleanup(
-    session: Awaited<ReturnType<CopilotClient["createSession"]>> | undefined,
+    session:
+      | Awaited<ReturnType<CopilotClient["createSession"]>>
+      | undefined,
     client: CopilotClient,
   ): Promise<void> {
     try {
@@ -229,4 +394,24 @@ export class CopilotAdapter implements CopilotPort {
       // Swallow stop errors — cleanup should not mask original error
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Factory Function [HEXAGONAL]
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a CopilotAdapter instance behind the CopilotPort interface.
+ *
+ * [HEXAGONAL] Consumers use this factory instead of `new CopilotAdapter()`.
+ * Returns the port interface, hiding the concrete implementation.
+ * Follows the project's factory function convention (see createDefaultState).
+ *
+ * @param options - Adapter configuration (model, guardians path)
+ * @returns A CopilotPort implementation backed by the Copilot SDK
+ */
+export function createCopilotAdapter(
+  options: CopilotAdapterOptions,
+): CopilotPort {
+  return new CopilotAdapter(options);
 }

--- a/craig/src/copilot/copilot.errors.ts
+++ b/craig/src/copilot/copilot.errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Custom error types for the Copilot component.
+ *
+ * Each error type maps to a specific failure mode,
+ * giving consumers precise control over error handling.
+ *
+ * All errors accept an optional `{ cause }` option to preserve
+ * the original error chain for debugging.
+ *
+ * @module copilot
+ */
+
+/** Thrown when the Copilot SDK session fails to create or connect. */
+export class CopilotSessionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CopilotSessionError";
+  }
+}
+
+/** Thrown when a Guardian agent invocation exceeds the timeout. */
+export class CopilotTimeoutError extends Error {
+  public readonly timeout_ms: number;
+
+  constructor(timeout_ms: number, options?: ErrorOptions) {
+    super(`Timeout after ${timeout_ms}ms`, options);
+    this.name = "CopilotTimeoutError";
+    this.timeout_ms = timeout_ms;
+  }
+}
+
+/** Thrown when Copilot CLI/SDK is not installed or not authenticated. */
+export class CopilotUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CopilotUnavailableError";
+  }
+}

--- a/craig/src/copilot/copilot.port.ts
+++ b/craig/src/copilot/copilot.port.ts
@@ -1,0 +1,44 @@
+/**
+ * CopilotPort — Public interface for the Copilot component.
+ *
+ * All consumers depend on this port, never on the implementation.
+ * This boundary ensures the copilot adapter (SDK-based) is rewritable
+ * without changing any downstream component.
+ *
+ * Could be reimplemented with:
+ * - Copilot CLI `-p` flag (subprocess invocation)
+ * - Mock adapter for testing
+ * - Alternative LLM SDK
+ *
+ * @module copilot
+ */
+
+import type { InvokeParams, InvokeResult } from "./copilot.types.js";
+
+/**
+ * Port (interface) for Copilot SDK interaction.
+ *
+ * Consumers depend on this contract. The adapter behind it
+ * can be swapped (SDK, CLI, mock) without changing consumer code.
+ *
+ * [HEXAGONAL] Inward-facing port. Adapters implement this.
+ */
+export interface CopilotPort {
+  /**
+   * Invoke a Guardian agent and capture its output.
+   *
+   * Creates a session, sends the prompt, waits for the response,
+   * and cleans up the session. Each invocation is independent.
+   *
+   * @param params - Invocation parameters (agent, prompt, context, model, timeout)
+   * @returns The invocation result with raw markdown output
+   */
+  invoke(params: InvokeParams): Promise<InvokeResult>;
+
+  /**
+   * Check whether the Copilot SDK / CLI is available and authenticated.
+   *
+   * @returns true if Copilot is ready for invocations, false otherwise
+   */
+  isAvailable(): Promise<boolean>;
+}

--- a/craig/src/copilot/copilot.types.ts
+++ b/craig/src/copilot/copilot.types.ts
@@ -1,0 +1,67 @@
+/**
+ * Copilot component — Type definitions.
+ *
+ * Defines the data models owned by the copilot component:
+ * InvokeParams, InvokeResult, and Guardian agent names.
+ *
+ * @module copilot
+ */
+
+// ---------------------------------------------------------------------------
+// Guardian Agent Types
+// ---------------------------------------------------------------------------
+
+/** Supported Guardian agent names for invocation. */
+export type GuardianAgent =
+  | "security-guardian"
+  | "code-review-guardian"
+  | "qa-guardian"
+  | "po-guardian";
+
+// ---------------------------------------------------------------------------
+// Invocation Data Models
+// ---------------------------------------------------------------------------
+
+/**
+ * Parameters for invoking a Guardian agent.
+ *
+ * @see Issue #5 — Interface Contract
+ */
+export interface InvokeParams {
+  /** Which Guardian agent to invoke. */
+  readonly agent: GuardianAgent;
+
+  /** The task description / prompt for the agent. */
+  readonly prompt: string;
+
+  /** Additional context (diff, file list, etc.). */
+  readonly context?: string;
+
+  /** Override model from config. */
+  readonly model?: string;
+
+  /** Timeout in milliseconds. Default: 300_000 (5 min). */
+  readonly timeout?: number;
+}
+
+/**
+ * Result of a Guardian agent invocation.
+ *
+ * @see Issue #5 — Interface Contract
+ */
+export interface InvokeResult {
+  /** Whether the invocation succeeded. */
+  readonly success: boolean;
+
+  /** Raw agent output (markdown). Empty string on failure. */
+  readonly output: string;
+
+  /** Duration of the invocation in milliseconds. */
+  readonly duration_ms: number;
+
+  /** Model used for the invocation. */
+  readonly model_used: string;
+
+  /** Error message if success is false. */
+  readonly error?: string;
+}

--- a/craig/src/copilot/copilot.types.ts
+++ b/craig/src/copilot/copilot.types.ts
@@ -18,6 +18,31 @@ export type GuardianAgent =
   | "qa-guardian"
   | "po-guardian";
 
+/**
+ * Runtime set of valid Guardian agent names.
+ *
+ * Used for runtime validation of agent names from untrusted input
+ * (config files, API payloads). Mirrors the GuardianAgent union.
+ *
+ * [SECURITY] Prevents arbitrary agent invocation via injection.
+ */
+export const GUARDIAN_AGENTS: ReadonlySet<string> = new Set<string>([
+  "security-guardian",
+  "code-review-guardian",
+  "qa-guardian",
+  "po-guardian",
+]);
+
+/**
+ * Type guard: checks if a string is a valid GuardianAgent at runtime.
+ *
+ * @param value - The string to validate
+ * @returns true if the value is a valid GuardianAgent name
+ */
+export function isGuardianAgent(value: string): value is GuardianAgent {
+  return GUARDIAN_AGENTS.has(value);
+}
+
 // ---------------------------------------------------------------------------
 // Invocation Data Models
 // ---------------------------------------------------------------------------
@@ -45,15 +70,38 @@ export interface InvokeParams {
 }
 
 /**
- * Result of a Guardian agent invocation.
+ * Successful Guardian agent invocation result.
+ *
+ * Narrow via `result.success === true` to access output safely.
  *
  * @see Issue #5 — Interface Contract
  */
-export interface InvokeResult {
-  /** Whether the invocation succeeded. */
-  readonly success: boolean;
+export interface InvokeSuccess {
+  /** Discriminant: invocation succeeded. */
+  readonly success: true;
 
-  /** Raw agent output (markdown). Empty string on failure. */
+  /** Raw agent output (markdown). */
+  readonly output: string;
+
+  /** Duration of the invocation in milliseconds. */
+  readonly duration_ms: number;
+
+  /** Model used for the invocation. */
+  readonly model_used: string;
+}
+
+/**
+ * Failed Guardian agent invocation result.
+ *
+ * Narrow via `result.success === false` to access error safely.
+ *
+ * @see Issue #5 — Interface Contract
+ */
+export interface InvokeFailure {
+  /** Discriminant: invocation failed. */
+  readonly success: false;
+
+  /** Always empty string on failure. */
   readonly output: string;
 
   /** Duration of the invocation in milliseconds. */
@@ -62,6 +110,18 @@ export interface InvokeResult {
   /** Model used for the invocation. */
   readonly model_used: string;
 
-  /** Error message if success is false. */
-  readonly error?: string;
+  /** Error message describing the failure. Always present on failure. */
+  readonly error: string;
 }
+
+/**
+ * Discriminated union for Guardian agent invocation results.
+ *
+ * Narrow via `result.success` to get type-safe access:
+ * - `true`  → InvokeSuccess (output present, no error field)
+ * - `false` → InvokeFailure (error required, output empty)
+ *
+ * [CLEAN-CODE] Eliminates impossible states — success cannot have error,
+ * failure always has error.
+ */
+export type InvokeResult = InvokeSuccess | InvokeFailure;

--- a/craig/src/copilot/index.ts
+++ b/craig/src/copilot/index.ts
@@ -7,14 +7,22 @@
  * @module copilot
  */
 
-export { CopilotAdapter } from "./copilot.adapter.js";
+export {
+  CopilotAdapter,
+  createCopilotAdapter,
+  createScopedPermissionHandler,
+  sanitizeInput,
+} from "./copilot.adapter.js";
 export type { CopilotAdapterOptions } from "./copilot.adapter.js";
 export type { CopilotPort } from "./copilot.port.js";
 export type {
   InvokeParams,
   InvokeResult,
+  InvokeSuccess,
+  InvokeFailure,
   GuardianAgent,
 } from "./copilot.types.js";
+export { GUARDIAN_AGENTS, isGuardianAgent } from "./copilot.types.js";
 export {
   CopilotSessionError,
   CopilotTimeoutError,

--- a/craig/src/copilot/index.ts
+++ b/craig/src/copilot/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Copilot component — public API barrel export.
+ *
+ * All consumers import from here, never from internals.
+ * This is the component boundary.
+ *
+ * @module copilot
+ */
+
+export { CopilotAdapter } from "./copilot.adapter.js";
+export type { CopilotAdapterOptions } from "./copilot.adapter.js";
+export type { CopilotPort } from "./copilot.port.js";
+export type {
+  InvokeParams,
+  InvokeResult,
+  GuardianAgent,
+} from "./copilot.types.js";
+export {
+  CopilotSessionError,
+  CopilotTimeoutError,
+  CopilotUnavailableError,
+} from "./copilot.errors.js";


### PR DESCRIPTION
## Summary

Implements **Copilot SDK Integration** for Craig — the copilot component that allows Craig to programmatically invoke SDLC Guardian agents and capture their structured output.

Closes #5

## What was implemented

### New component: `craig/src/copilot/`

| File | Purpose |
|------|---------|
| `copilot.port.ts` | CopilotPort interface (hexagonal port) |
| `copilot.adapter.ts` | SDK-based implementation using `@github/copilot-sdk` |
| `copilot.types.ts` | InvokeParams, InvokeResult, GuardianAgent types |
| `copilot.errors.ts` | CopilotSessionError, CopilotTimeoutError, CopilotUnavailableError |
| `index.ts` | Barrel export (component boundary) |
| `__tests__/copilot.adapter.test.ts` | 33 unit tests (TDD, all mocked) |

### Acceptance criteria covered

- **AC1**: Invoke Guardian agents by name, capture markdown output ✅
- **AC2**: Handle timeout (default 5min, configurable per invocation) ✅
- **AC3**: Check SDK availability and authentication via `isAvailable()` ✅
- **AC4**: Retry once on session creation failure ✅
- **AC5**: Model selection from config with per-invocation override ✅

### Architecture

```
Analyzer Components
        │
        ▼ (depend on port)
  ┌─────────────┐
  │ CopilotPort │ ← interface (copilot.port.ts)
  └─────┬───────┘
        │ implements
        ▼
  ┌──────────────────┐
  │ CopilotAdapter   │ ← adapter (copilot.adapter.ts)
  │ @github/copilot- │
  │ sdk v0.1.32      │
  └──────────────────┘
```

### Design decisions

| # | Decision | Rationale | Reversible? |
|---|----------|-----------|-------------|
| 1 | One CopilotClient per invocation | No shared state, prevents session leaks, matches SDK concurrency model | Yes |
| 2 | Prompt format: `@{agent} {prompt}` | Agent routing via @-mention convention in Copilot | Yes |
| 3 | Never throws — returns `InvokeResult` with `success: false` | Callers can handle errors without try/catch | No (contract) |
| 4 | `approveAll` permission handler | Craig runs autonomously — needs all permissions | Yes |
| 5 | Fixed `yaml`/`zod` missing deps in package.json | Pre-existing merge conflict in main left dependencies unresolvable | Yes |

### Dependencies added

- `@github/copilot-sdk@^0.1.32` (production)
- `yaml@^2.8.2` (production — was missing, needed by config)
- `zod@^4.3.6` (production — was missing, needed by config)

### Tests

- **33 unit tests**, all passing
- All SDK interactions mocked — no real API calls
- Covers: success path, timeout, unavailable, retry, model selection, edge cases
- Full suite: **120 tests passing** (33 new + 87 existing)

### Pre-compliance

- [x] No hardcoded secrets
- [x] No sensitive data in logs
- [x] Error responses don't leak internals
- [x] Cyclomatic complexity < 10 per function
- [x] No code duplication
- [x] Functions < 30 lines
- [x] Clear, consistent naming
- [x] All new code has unit tests
- [x] Edge cases covered
