### PR TITLE
feat(analyzer): Pattern Learner & Enforcer

### DIFF
--- a/craig/src/analyzers/index.ts
+++ b/craig/src/analyzers/index.ts
@@ -36,3 +36,16 @@ export type {
 export type { LinterDefinition, FixerResult } from "./auto-fix/auto-fix.types.js";
 export { SUPPORTED_LINTERS } from "./auto-fix/auto-fix.types.js";
 export { FixVerificationError, GitOpsError } from "./auto-fix/auto-fix.errors.js";
+export { PatternCheckAnalyzer } from "./pattern-check/index.js";
+export { FilePatternStore } from "./pattern-check/file-pattern-store.js";
+export type { PatternStorePort } from "./pattern-check/pattern-store.port.js";
+export type {
+  PatternSet,
+  PatternRule,
+  PatternSeverity,
+  PatternDeviation,
+} from "./pattern-check/types.js";
+export {
+  PatternStoreCorruptedError,
+  PatternLearningError,
+} from "./pattern-check/errors.js";

--- a/craig/src/analyzers/pattern-check/__tests__/file-pattern-store.test.ts
+++ b/craig/src/analyzers/pattern-check/__tests__/file-pattern-store.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for FilePatternStore — the persistence adapter for learned patterns.
+ *
+ * Tests written FIRST per TDD. Each acceptance criterion from issue #14
+ * maps to one or more tests.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/14
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { FilePatternStore } from "../file-pattern-store.js";
+import type { CopilotPort } from "../../../copilot/index.js";
+import type { PatternSet } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "craig-pattern-test-"));
+}
+
+function createMockCopilot(): CopilotPort {
+  return {
+    invoke: vi.fn().mockResolvedValue({
+      success: true,
+      output: JSON.stringify({
+        naming_conventions: [
+          {
+            name: "camelCase-functions",
+            pattern: "Functions use camelCase naming",
+            frequency: "42/45 files",
+            severity: "warning",
+            description: "All exported functions use camelCase naming convention",
+          },
+        ],
+        file_structure: [
+          {
+            name: "barrel-exports",
+            pattern: "Each module has an index.ts barrel export",
+            frequency: "8/8 modules",
+            severity: "info",
+            description: "All component directories export via index.ts",
+          },
+        ],
+        error_handling: [
+          {
+            name: "result-type-pattern",
+            pattern: "Error handling uses discriminated union Result types",
+            frequency: "15/18 files",
+            severity: "warning",
+            description: "Functions return success/failure unions instead of throwing",
+          },
+        ],
+        import_conventions: [
+          {
+            name: "js-extension-imports",
+            pattern: "Imports use .js extension for local modules",
+            frequency: "40/40 files",
+            severity: "warning",
+            description: "All local imports include .js extension for ESM compatibility",
+          },
+        ],
+      }),
+      duration_ms: 5000,
+      model_used: "claude-sonnet-4.5",
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createValidPatternSet(): PatternSet {
+  return {
+    naming_conventions: [
+      {
+        name: "camelCase-functions",
+        pattern: "Functions use camelCase naming",
+        frequency: "42/45 files",
+        severity: "warning",
+        description: "All exported functions use camelCase naming convention",
+      },
+    ],
+    file_structure: [
+      {
+        name: "barrel-exports",
+        pattern: "Each module has an index.ts barrel export",
+        frequency: "8/8 modules",
+        severity: "info",
+        description: "All component directories export via index.ts",
+      },
+    ],
+    error_handling: [
+      {
+        name: "result-type-pattern",
+        pattern: "Error handling uses discriminated union Result types",
+        frequency: "15/18 files",
+        severity: "warning",
+        description: "Functions return success/failure unions instead of throwing",
+      },
+    ],
+    import_conventions: [
+      {
+        name: "js-extension-imports",
+        pattern: "Imports use .js extension for local modules",
+        frequency: "40/40 files",
+        severity: "warning",
+        description: "All local imports include .js extension for ESM compatibility",
+      },
+    ],
+    learned_at: "2025-07-10T08:00:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FilePatternStore", () => {
+  let tmpDir: string;
+  let copilot: CopilotPort;
+  let store: FilePatternStore;
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir();
+    copilot = createMockCopilot();
+    store = new FilePatternStore(tmpDir, copilot);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC1: Learn patterns from repo
+  // -----------------------------------------------------------------------
+
+  describe("AC1: Learn patterns from repo", () => {
+    it("should invoke Code Review Guardian to analyze the repository", async () => {
+      await store.learn("/path/to/repo");
+
+      expect(copilot.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: "code-review-guardian",
+          prompt: expect.stringContaining("Analyze"),
+        }),
+      );
+    });
+
+    it("should return a valid PatternSet from learned patterns", async () => {
+      const patterns = await store.learn("/path/to/repo");
+
+      expect(patterns.naming_conventions).toHaveLength(1);
+      expect(patterns.file_structure).toHaveLength(1);
+      expect(patterns.error_handling).toHaveLength(1);
+      expect(patterns.import_conventions).toHaveLength(1);
+      expect(patterns.learned_at).toBeDefined();
+      expect(new Date(patterns.learned_at).toISOString()).toBe(
+        patterns.learned_at,
+      );
+    });
+
+    it("should set learned_at to current ISO timestamp", async () => {
+      const before = new Date().toISOString();
+      const patterns = await store.learn("/path/to/repo");
+      const after = new Date().toISOString();
+
+      expect(patterns.learned_at >= before).toBe(true);
+      expect(patterns.learned_at <= after).toBe(true);
+    });
+
+    it("should include repoPath in the Copilot prompt context", async () => {
+      await store.learn("/my/project/path");
+
+      expect(copilot.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.stringContaining("/my/project/path"),
+        }),
+      );
+    });
+
+    it("should throw PatternLearningError when Copilot invocation fails", async () => {
+      vi.mocked(copilot.invoke).mockResolvedValue({
+        success: false,
+        output: "",
+        duration_ms: 100,
+        model_used: "claude-sonnet-4.5",
+        error: "Session timeout",
+      });
+
+      await expect(store.learn("/path/to/repo")).rejects.toThrow(
+        "Pattern learning failed",
+      );
+    });
+
+    it("should throw PatternLearningError when Copilot returns unparseable output", async () => {
+      vi.mocked(copilot.invoke).mockResolvedValue({
+        success: true,
+        output: "This is not valid JSON at all",
+        duration_ms: 100,
+        model_used: "claude-sonnet-4.5",
+      });
+
+      await expect(store.learn("/path/to/repo")).rejects.toThrow(
+        "Pattern learning failed",
+      );
+    });
+
+    it("should handle Copilot output with markdown code fences around JSON", async () => {
+      vi.mocked(copilot.invoke).mockResolvedValue({
+        success: true,
+        output: "```json\n" + JSON.stringify({
+          naming_conventions: [],
+          file_structure: [],
+          error_handling: [],
+          import_conventions: [],
+        }) + "\n```",
+        duration_ms: 100,
+        model_used: "claude-sonnet-4.5",
+      });
+
+      const patterns = await store.learn("/path/to/repo");
+
+      expect(patterns.naming_conventions).toEqual([]);
+      expect(patterns.learned_at).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // load() and save()
+  // -----------------------------------------------------------------------
+
+  describe("load()", () => {
+    it("should return null when no patterns file exists", async () => {
+      const result = await store.load();
+
+      expect(result).toBeNull();
+    });
+
+    it("should return saved PatternSet from .craig-patterns.json", async () => {
+      const patterns = createValidPatternSet();
+      const filePath = path.join(tmpDir, ".craig-patterns.json");
+      await fs.writeFile(filePath, JSON.stringify(patterns), "utf-8");
+
+      const result = await store.load();
+
+      expect(result).not.toBeNull();
+      expect(result!.naming_conventions).toHaveLength(1);
+      expect(result!.naming_conventions[0]!.name).toBe("camelCase-functions");
+      expect(result!.learned_at).toBe("2025-07-10T08:00:00.000Z");
+    });
+
+    it("should return null and back up corrupted file", async () => {
+      const filePath = path.join(tmpDir, ".craig-patterns.json");
+      await fs.writeFile(filePath, "{ this is not valid json }", "utf-8");
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await store.load();
+
+      expect(result).toBeNull();
+
+      // Verify backup was created
+      const backupExists = await fs
+        .access(filePath + ".bak")
+        .then(() => true)
+        .catch(() => false);
+      expect(backupExists).toBe(true);
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe("save()", () => {
+    it("should persist PatternSet to .craig-patterns.json", async () => {
+      const patterns = createValidPatternSet();
+
+      await store.save(patterns);
+
+      const filePath = path.join(tmpDir, ".craig-patterns.json");
+      const content = await fs.readFile(filePath, "utf-8");
+      const saved = JSON.parse(content) as PatternSet;
+
+      expect(saved.naming_conventions).toHaveLength(1);
+      expect(saved.learned_at).toBe("2025-07-10T08:00:00.000Z");
+    });
+
+    it("should use atomic writes (write to .tmp, then rename)", async () => {
+      const patterns = createValidPatternSet();
+
+      await store.save(patterns);
+
+      // The .tmp file should NOT exist after save completes
+      const tmpExists = await fs
+        .access(path.join(tmpDir, ".craig-patterns.json.tmp"))
+        .then(() => true)
+        .catch(() => false);
+      expect(tmpExists).toBe(false);
+
+      // The actual file should exist
+      const fileExists = await fs
+        .access(path.join(tmpDir, ".craig-patterns.json"))
+        .then(() => true)
+        .catch(() => false);
+      expect(fileExists).toBe(true);
+    });
+
+    it("should overwrite existing patterns file", async () => {
+      const original = createValidPatternSet();
+      await store.save(original);
+
+      const updated: PatternSet = {
+        ...original,
+        learned_at: "2025-08-01T12:00:00.000Z",
+        naming_conventions: [],
+      };
+      await store.save(updated);
+
+      const result = await store.load();
+      expect(result!.naming_conventions).toHaveLength(0);
+      expect(result!.learned_at).toBe("2025-08-01T12:00:00.000Z");
+    });
+
+    it("should produce valid JSON with 2-space indentation", async () => {
+      const patterns = createValidPatternSet();
+
+      await store.save(patterns);
+
+      const filePath = path.join(tmpDir, ".craig-patterns.json");
+      const content = await fs.readFile(filePath, "utf-8");
+
+      // Verify it's formatted with 2-space indent
+      expect(content).toContain("  ");
+      expect(content.endsWith("\n")).toBe(true);
+    });
+  });
+});

--- a/craig/src/analyzers/pattern-check/__tests__/pattern-check.analyzer.test.ts
+++ b/craig/src/analyzers/pattern-check/__tests__/pattern-check.analyzer.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for PatternCheckAnalyzer — the core pattern enforcement logic.
+ *
+ * Tests written FIRST per TDD. Each acceptance criterion from issue #14
+ * maps to one or more tests.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/14
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PatternCheckAnalyzer } from "../pattern-check.analyzer.js";
+import type { PatternStorePort } from "../pattern-store.port.js";
+import type { PatternSet } from "../types.js";
+import type { CopilotPort } from "../../../copilot/index.js";
+import type { AnalyzerContext } from "../../analyzer.port.js";
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+function createMockPatternStore(): PatternStorePort {
+  return {
+    learn: vi.fn().mockResolvedValue(createValidPatternSet()),
+    load: vi.fn().mockResolvedValue(createValidPatternSet()),
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockCopilot(): CopilotPort {
+  return {
+    invoke: vi.fn().mockResolvedValue({
+      success: true,
+      output: `## Pattern Deviation Review
+
+### Findings
+
+| # | Severity | Category | File:Line | Issue | Source & Justification | Suggested Fix |
+|---|----------|----------|-----------|-------|----------------------|---------------|
+| 1 | 🟡 Medium | Pattern Deviation | src/new-file.ts:15 | Uses try/catch instead of Result type pattern (15/18 files use Result) | [CUSTOM] Repo convention | Refactor to use Result<T, E> discriminated union |
+| 2 | 🔵 Low | Pattern Deviation | src/new-file.ts:3 | Uses relative imports without .js extension (40/40 files use .js) | [CUSTOM] Repo convention | Add .js extension to import |`,
+      duration_ms: 3000,
+      model_used: "claude-sonnet-4.5",
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createValidPatternSet(): PatternSet {
+  return {
+    naming_conventions: [
+      {
+        name: "camelCase-functions",
+        pattern: "Functions use camelCase naming",
+        frequency: "42/45 files",
+        severity: "warning",
+        description: "All exported functions use camelCase naming convention",
+      },
+    ],
+    file_structure: [
+      {
+        name: "barrel-exports",
+        pattern: "Each module has an index.ts barrel export",
+        frequency: "8/8 modules",
+        severity: "info",
+        description: "All component directories export via index.ts",
+      },
+    ],
+    error_handling: [
+      {
+        name: "result-type-pattern",
+        pattern: "Error handling uses discriminated union Result types",
+        frequency: "15/18 files",
+        severity: "warning",
+        description: "Functions return success/failure unions instead of throwing",
+      },
+    ],
+    import_conventions: [
+      {
+        name: "js-extension-imports",
+        pattern: "Imports use .js extension for local modules",
+        frequency: "40/40 files",
+        severity: "warning",
+        description: "All local imports include .js extension for ESM compatibility",
+      },
+    ],
+    learned_at: "2025-07-10T08:00:00.000Z",
+  };
+}
+
+function createMergeContext(diff?: string): AnalyzerContext {
+  return {
+    trigger: "merge",
+    sha: "abc123def456",
+    diff: diff ?? `diff --git a/src/new-file.ts b/src/new-file.ts
+new file mode 100644
+--- /dev/null
++++ b/src/new-file.ts
+@@ -0,0 +1,20 @@
++import { something } from "./utils";
++
++export async function getData() {
++  try {
++    const result = await fetch("/api/data");
++    return result.json();
++  } catch (error) {
++    console.error(error);
++    throw error;
++  }
++}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PatternCheckAnalyzer", () => {
+  let patternStore: PatternStorePort;
+  let copilot: CopilotPort;
+  let analyzer: PatternCheckAnalyzer;
+
+  beforeEach(() => {
+    patternStore = createMockPatternStore();
+    copilot = createMockCopilot();
+    analyzer = new PatternCheckAnalyzer(patternStore, copilot);
+  });
+
+  // -----------------------------------------------------------------------
+  // Basic properties
+  // -----------------------------------------------------------------------
+
+  describe("analyzer identity", () => {
+    it('should have name "pattern_check"', () => {
+      expect(analyzer.name).toBe("pattern_check");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC1: Learn patterns (manual trigger)
+  // -----------------------------------------------------------------------
+
+  describe("AC1: Learn patterns on manual trigger", () => {
+    it("should call patternStore.learn when triggered manually with no existing patterns", async () => {
+      vi.mocked(patternStore.load).mockResolvedValue(null);
+
+      const result = await analyzer.execute({ trigger: "manual" });
+
+      expect(patternStore.learn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.task).toBe("pattern_check");
+    });
+
+    it("should save learned patterns after learning", async () => {
+      vi.mocked(patternStore.load).mockResolvedValue(null);
+
+      await analyzer.execute({ trigger: "manual" });
+
+      expect(patternStore.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          naming_conventions: expect.any(Array),
+          learned_at: expect.any(String),
+        }),
+      );
+    });
+
+    it("should re-learn patterns on manual trigger even when patterns exist", async () => {
+      vi.mocked(patternStore.load).mockResolvedValue(createValidPatternSet());
+
+      const result = await analyzer.execute({ trigger: "manual" });
+
+      expect(patternStore.learn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC2: Flag deviations on merge
+  // -----------------------------------------------------------------------
+
+  describe("AC2: Flag deviations on merge", () => {
+    it("should load existing patterns and invoke Code Review Guardian with diff", async () => {
+      const context = createMergeContext();
+
+      await analyzer.execute(context);
+
+      expect(patternStore.load).toHaveBeenCalled();
+      expect(copilot.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: "code-review-guardian",
+          prompt: expect.stringContaining("pattern"),
+          context: expect.stringContaining("diff"),
+        }),
+      );
+    });
+
+    it("should return findings from the Code Review Guardian analysis", async () => {
+      const context = createMergeContext();
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.findings.length).toBeGreaterThan(0);
+      expect(result.task).toBe("pattern_check");
+    });
+
+    it("should include duration_ms in the result", async () => {
+      const context = createMergeContext();
+
+      const result = await analyzer.execute(context);
+
+      expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should pass learned patterns as context to Code Review Guardian", async () => {
+      const context = createMergeContext();
+
+      await analyzer.execute(context);
+
+      const invokeCall = vi.mocked(copilot.invoke).mock.calls[0]![0];
+      expect(invokeCall.context).toContain("camelCase-functions");
+      expect(invokeCall.context).toContain("result-type-pattern");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // AC3: Include deviations in merge review
+  // -----------------------------------------------------------------------
+
+  describe("AC3: Include deviations in merge review comment", () => {
+    it("should return structured findings that can be composed into review comments", async () => {
+      const context = createMergeContext();
+
+      const result = await analyzer.execute(context);
+
+      expect(result.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            severity: expect.any(String),
+            issue: expect.stringContaining("try/catch"),
+          }),
+        ]),
+      );
+    });
+
+    it("should include empty actions_taken when no issues are created", async () => {
+      const context = createMergeContext();
+
+      const result = await analyzer.execute(context);
+
+      expect(result.actions_taken).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge Cases
+  // -----------------------------------------------------------------------
+
+  describe("Edge case: No learned patterns", () => {
+    it("should skip pattern check and return info message when no patterns exist on merge", async () => {
+      vi.mocked(patternStore.load).mockResolvedValue(null);
+
+      const context = createMergeContext();
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toEqual([]);
+      expect(result.error).toContain(
+        "run `craig_run_task pattern_check` to learn patterns first",
+      );
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe("Edge case: Corrupted patterns file", () => {
+    it("should re-learn patterns when load throws an error", async () => {
+      vi.mocked(patternStore.load).mockRejectedValue(
+        new Error("Parse error"),
+      );
+
+      const context: AnalyzerContext = { trigger: "manual" };
+
+      const result = await analyzer.execute(context);
+
+      expect(patternStore.learn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("Edge case: Copilot unavailable", () => {
+    it("should return success false when Copilot invocation fails on merge", async () => {
+      vi.mocked(copilot.invoke).mockResolvedValue({
+        success: false,
+        output: "",
+        duration_ms: 100,
+        model_used: "claude-sonnet-4.5",
+        error: "Copilot session timeout",
+      });
+
+      const context = createMergeContext();
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Copilot session timeout");
+    });
+  });
+
+  describe("Edge case: Diff is empty or missing", () => {
+    it("should return success with no findings when diff is empty", async () => {
+      const context: AnalyzerContext = {
+        trigger: "merge",
+        sha: "abc123",
+        diff: "",
+      };
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toEqual([]);
+    });
+
+    it("should return success with no findings when diff is undefined on merge", async () => {
+      const context: AnalyzerContext = {
+        trigger: "merge",
+        sha: "abc123",
+      };
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toEqual([]);
+    });
+  });
+
+  describe("Edge case: Schedule trigger", () => {
+    it("should re-learn patterns on schedule trigger", async () => {
+      const context: AnalyzerContext = { trigger: "schedule" };
+
+      const result = await analyzer.execute(context);
+
+      expect(patternStore.learn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Never throws
+  // -----------------------------------------------------------------------
+
+  describe("never throws — returns AnalyzerResult with success false", () => {
+    it("should return error result when learn throws unexpected error", async () => {
+      vi.mocked(patternStore.load).mockRejectedValue(
+        new Error("Unexpected error"),
+      );
+      vi.mocked(patternStore.learn).mockRejectedValue(
+        new Error("Disk full"),
+      );
+
+      const context: AnalyzerContext = { trigger: "manual" };
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Disk full");
+      expect(result.task).toBe("pattern_check");
+    });
+
+    it("should return error result when save throws after learning", async () => {
+      vi.mocked(patternStore.load).mockResolvedValue(null);
+      vi.mocked(patternStore.save).mockRejectedValue(
+        new Error("Permission denied"),
+      );
+
+      const context: AnalyzerContext = { trigger: "manual" };
+
+      const result = await analyzer.execute(context);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Permission denied");
+    });
+  });
+});

--- a/craig/src/analyzers/pattern-check/errors.ts
+++ b/craig/src/analyzers/pattern-check/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Custom error classes for the Pattern Check analyzer component.
+ *
+ * Follows the project convention: custom Error subclasses with
+ * descriptive names and contextual properties.
+ *
+ * @module analyzers/pattern-check/errors
+ */
+
+/**
+ * Thrown when the `.craig-patterns.json` file contains invalid JSON
+ * or does not conform to the expected PatternSet schema.
+ *
+ * When this occurs, the corrupted file is backed up and patterns
+ * must be re-learned from the repository.
+ */
+export class PatternStoreCorruptedError extends Error {
+  constructor(
+    public readonly filePath: string,
+    public readonly cause: unknown,
+  ) {
+    super(
+      `Pattern store corrupted: ${filePath}. Backed up to ${filePath}.bak and must re-learn patterns.`,
+    );
+    this.name = "PatternStoreCorruptedError";
+  }
+}
+
+/**
+ * Thrown when pattern learning fails (e.g., Copilot invocation fails
+ * or the response cannot be parsed into a valid PatternSet).
+ */
+export class PatternLearningError extends Error {
+  constructor(
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "PatternLearningError";
+  }
+}

--- a/craig/src/analyzers/pattern-check/file-pattern-store.ts
+++ b/craig/src/analyzers/pattern-check/file-pattern-store.ts
@@ -1,0 +1,241 @@
+/**
+ * FilePatternStore — Adapter for persisting learned patterns to disk.
+ *
+ * Implements the PatternStorePort interface. Stores patterns in
+ * `.craig-patterns.json` using atomic writes (temp file + rename).
+ *
+ * Learning is delegated to Code Review Guardian via CopilotPort.
+ * The adapter handles JSON parsing, validation, corruption recovery,
+ * and file I/O.
+ *
+ * [HEXAGONAL] Adapter implementing PatternStorePort.
+ * [CLEAN-CODE] SRP — only responsible for pattern persistence + learning.
+ *
+ * @module analyzers/pattern-check/file-pattern-store
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { CopilotPort } from "../../copilot/index.js";
+import type { PatternStorePort } from "./pattern-store.port.js";
+import type { PatternSet, PatternRule } from "./types.js";
+import { PatternLearningError } from "./errors.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PATTERNS_FILENAME = ".craig-patterns.json";
+const TEMP_SUFFIX = ".tmp";
+const BACKUP_SUFFIX = ".bak";
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * File-based adapter for pattern storage.
+ *
+ * Persists patterns to `.craig-patterns.json` in the specified directory.
+ * Learning is performed by invoking Code Review Guardian via CopilotPort.
+ */
+export class FilePatternStore implements PatternStorePort {
+  private readonly filePath: string;
+
+  constructor(
+    baseDir: string,
+    private readonly copilot: CopilotPort,
+  ) {
+    this.filePath = path.join(baseDir, PATTERNS_FILENAME);
+  }
+
+  /**
+   * Analyze the repository and learn coding patterns via Code Review Guardian.
+   *
+   * Invokes Code Review Guardian with a structured prompt asking it
+   * to analyze the codebase and return a JSON PatternSet.
+   *
+   * @param repoPath - Path to the repository root
+   * @returns Learned PatternSet with current timestamp
+   * @throws PatternLearningError if Copilot fails or returns unparseable output
+   */
+  async learn(repoPath: string): Promise<PatternSet> {
+    const result = await this.copilot.invoke({
+      agent: "code-review-guardian",
+      prompt: this.buildLearnPrompt(),
+      context: `Repository path: ${repoPath}`,
+    });
+
+    if (!result.success) {
+      throw new PatternLearningError(
+        `Pattern learning failed: ${result.error}`,
+      );
+    }
+
+    const parsed = this.parseLearnedPatterns(result.output);
+
+    return {
+      ...parsed,
+      learned_at: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Load patterns from `.craig-patterns.json`.
+   *
+   * Returns null if the file doesn't exist. If the file is corrupted,
+   * backs it up to `.bak` and returns null.
+   *
+   * @returns PatternSet or null
+   */
+  async load(): Promise<PatternSet | null> {
+    try {
+      const content = await fs.readFile(this.filePath, "utf-8");
+      return JSON.parse(content) as PatternSet;
+    } catch (error: unknown) {
+      if (isFileNotFoundError(error)) {
+        return null;
+      }
+
+      // File exists but is corrupted — back up and return null
+      console.error(
+        `[Craig] Pattern store corrupted: ${this.filePath}. Backing up.`,
+      );
+      await this.backupCorruptedFile();
+      return null;
+    }
+  }
+
+  /**
+   * Persist patterns to `.craig-patterns.json` using atomic writes.
+   *
+   * Writes to a `.tmp` file first, then renames to the final path.
+   * This prevents corruption from partial writes.
+   *
+   * @param patterns - The PatternSet to persist
+   */
+  async save(patterns: PatternSet): Promise<void> {
+    const tmpPath = this.filePath + TEMP_SUFFIX;
+    const content = JSON.stringify(patterns, null, 2) + "\n";
+
+    await fs.writeFile(tmpPath, content, "utf-8");
+    await fs.rename(tmpPath, this.filePath);
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Build the prompt for Code Review Guardian to analyze repository patterns.
+   */
+  private buildLearnPrompt(): string {
+    return [
+      "Analyze this repository's codebase and identify established coding patterns.",
+      "Return a JSON object (no markdown, no explanation) with these exact keys:",
+      "",
+      "- naming_conventions: Array of PatternRule objects for naming patterns",
+      "- file_structure: Array of PatternRule objects for directory/file structure patterns",
+      "- error_handling: Array of PatternRule objects for error handling patterns",
+      "- import_conventions: Array of PatternRule objects for import/export patterns",
+      "",
+      "Each PatternRule must have:",
+      '- name: string (kebab-case identifier, e.g. "camelCase-functions")',
+      '- pattern: string (description of the pattern observed)',
+      '- frequency: string (e.g. "15/18 files")',
+      '- severity: "warning" or "info"',
+      '- description: string (human-readable explanation)',
+      "",
+      "Focus on patterns that appear in the MAJORITY of files.",
+      "Only include patterns with clear evidence (frequency > 50%).",
+      "Return ONLY the JSON object, no other text.",
+    ].join("\n");
+  }
+
+  /**
+   * Parse the JSON output from Code Review Guardian into a PatternSet.
+   *
+   * Handles JSON wrapped in markdown code fences (`\`\`\`json ... \`\`\``).
+   *
+   * @throws PatternLearningError if the output cannot be parsed
+   */
+  private parseLearnedPatterns(output: string): Omit<PatternSet, "learned_at"> {
+    const jsonString = this.extractJson(output);
+
+    try {
+      const parsed = JSON.parse(jsonString) as Record<string, unknown>;
+
+      return {
+        naming_conventions: this.validateRules(parsed.naming_conventions),
+        file_structure: this.validateRules(parsed.file_structure),
+        error_handling: this.validateRules(parsed.error_handling),
+        import_conventions: this.validateRules(parsed.import_conventions),
+      };
+    } catch (error: unknown) {
+      throw new PatternLearningError(
+        `Pattern learning failed: unable to parse Copilot output as JSON`,
+        { cause: error },
+      );
+    }
+  }
+
+  /**
+   * Extract JSON from output that may be wrapped in markdown code fences.
+   */
+  private extractJson(output: string): string {
+    // Match ```json ... ``` or ``` ... ```
+    const fenceMatch = output.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+    if (fenceMatch?.[1]) {
+      return fenceMatch[1].trim();
+    }
+    return output.trim();
+  }
+
+  /**
+   * Validate and normalize an array of pattern rules.
+   * Returns empty array if input is not a valid array.
+   */
+  private validateRules(input: unknown): PatternRule[] {
+    if (!Array.isArray(input)) {
+      return [];
+    }
+
+    return input
+      .filter((item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null,
+      )
+      .map((item) => ({
+        name: String(item.name ?? ""),
+        pattern: String(item.pattern ?? ""),
+        frequency: String(item.frequency ?? ""),
+        severity: item.severity === "info" ? "info" as const : "warning" as const,
+        description: String(item.description ?? ""),
+      }));
+  }
+
+  /**
+   * Back up a corrupted patterns file to `.bak`.
+   */
+  private async backupCorruptedFile(): Promise<void> {
+    try {
+      await fs.copyFile(this.filePath, this.filePath + BACKUP_SUFFIX);
+    } catch {
+      // If backup fails too, just proceed — the corrupted file will be overwritten on next save
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an error is a "file not found" error (ENOENT).
+ */
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/craig/src/analyzers/pattern-check/index.ts
+++ b/craig/src/analyzers/pattern-check/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Pattern Check Analyzer — Public API
+ *
+ * Barrel export for the pattern-check analyzer component.
+ * Consumers import from here, not from internal modules.
+ *
+ * @module analyzers/pattern-check
+ */
+
+export { PatternCheckAnalyzer } from "./pattern-check.analyzer.js";
+export { FilePatternStore } from "./file-pattern-store.js";
+export type { PatternStorePort } from "./pattern-store.port.js";
+export type {
+  PatternSet,
+  PatternRule,
+  PatternSeverity,
+  PatternDeviation,
+} from "./types.js";
+export {
+  PatternStoreCorruptedError,
+  PatternLearningError,
+} from "./errors.js";

--- a/craig/src/analyzers/pattern-check/pattern-check.analyzer.ts
+++ b/craig/src/analyzers/pattern-check/pattern-check.analyzer.ts
@@ -1,0 +1,280 @@
+/**
+ * PatternCheckAnalyzer — Learns repo patterns and enforces them on new code.
+ *
+ * Implements the Analyzer interface. On manual/schedule triggers, learns
+ * patterns from the repository. On merge triggers, compares new code
+ * against learned patterns and flags deviations.
+ *
+ * [HEXAGONAL] Adapter implementing Analyzer port.
+ * [SOLID] SRP — pattern enforcement only.
+ * [CLEAN-CODE] Never throws from execute() — returns AnalyzerResult.
+ *
+ * @module analyzers/pattern-check/pattern-check-analyzer
+ */
+
+import type { Analyzer, AnalyzerContext, AnalyzerResult } from "../analyzer.port.js";
+import type { PatternStorePort } from "./pattern-store.port.js";
+import type { PatternSet } from "./types.js";
+import type { CopilotPort } from "../../copilot/index.js";
+import { createResultParser } from "../../result-parser/index.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TASK_NAME = "pattern_check";
+const NO_PATTERNS_MESSAGE =
+  "No learned patterns found. run `craig_run_task pattern_check` to learn patterns first";
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Analyzer that learns repository conventions and flags deviations.
+ *
+ * Two modes of operation:
+ * - **Learn** (manual/schedule): Analyzes the codebase and stores patterns
+ * - **Enforce** (merge): Compares new code against stored patterns
+ *
+ * Uses Code Review Guardian (via CopilotPort) for both learning and enforcement.
+ */
+export class PatternCheckAnalyzer implements Analyzer {
+  readonly name = TASK_NAME;
+
+  private readonly resultParser = createResultParser();
+
+  constructor(
+    private readonly patternStore: PatternStorePort,
+    private readonly copilot: CopilotPort,
+  ) {}
+
+  /**
+   * Execute the pattern check analysis.
+   *
+   * - Manual/Schedule triggers → learn (or re-learn) patterns
+   * - Merge triggers → enforce patterns against the diff
+   *
+   * Never throws — returns AnalyzerResult with success: false on error.
+   */
+  async execute(context: AnalyzerContext): Promise<AnalyzerResult> {
+    const startTime = Date.now();
+
+    try {
+      if (context.trigger === "merge") {
+        return await this.enforcePatterns(context, startTime);
+      }
+
+      return await this.learnPatterns(startTime);
+    } catch (error: unknown) {
+      return this.createErrorResult(error, startTime);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Learn mode
+  // -----------------------------------------------------------------------
+
+  /**
+   * Learn (or re-learn) patterns from the repository.
+   *
+   * On manual/schedule triggers, always re-learns to pick up new conventions.
+   * If loading existing patterns fails, proceeds to learn fresh.
+   */
+  private async learnPatterns(startTime: number): Promise<AnalyzerResult> {
+    const patterns = await this.patternStore.learn(".");
+    await this.patternStore.save(patterns);
+
+    return {
+      task: TASK_NAME,
+      success: true,
+      findings: [],
+      actions_taken: [],
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Enforce mode
+  // -----------------------------------------------------------------------
+
+  /**
+   * Enforce learned patterns against a merge diff.
+   *
+   * Loads existing patterns, builds a prompt with the patterns + diff,
+   * invokes Code Review Guardian, and parses the findings.
+   */
+  private async enforcePatterns(
+    context: AnalyzerContext,
+    startTime: number,
+  ): Promise<AnalyzerResult> {
+    // No diff → nothing to check
+    if (!context.diff) {
+      return {
+        task: TASK_NAME,
+        success: true,
+        findings: [],
+        actions_taken: [],
+        duration_ms: Date.now() - startTime,
+      };
+    }
+
+    // Load existing patterns
+    const patterns = await this.loadPatternsOrSkip(startTime);
+    if (patterns === null) {
+      return this.createSkipResult(startTime);
+    }
+
+    // Invoke Code Review Guardian with patterns + diff
+    const result = await this.copilot.invoke({
+      agent: "code-review-guardian",
+      prompt: this.buildEnforcePrompt(patterns),
+      context: this.buildEnforceContext(patterns, context.diff),
+    });
+
+    if (!result.success) {
+      return {
+        task: TASK_NAME,
+        success: false,
+        findings: [],
+        actions_taken: [],
+        duration_ms: Date.now() - startTime,
+        error: result.error,
+      };
+    }
+
+    // Parse the Guardian's response into structured findings
+    const report = this.resultParser.parse(result.output, "code-review");
+    const findings = report.findings;
+
+    return {
+      task: TASK_NAME,
+      success: true,
+      findings,
+      actions_taken: [],
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Attempt to load patterns. Returns null if no patterns exist.
+   *
+   * On load error, logs and returns null (skip mode).
+   */
+  private async loadPatternsOrSkip(_startTime: number): Promise<PatternSet | null> {
+    try {
+      return await this.patternStore.load();
+    } catch {
+      console.error(
+        `[Craig] Failed to load patterns. ${NO_PATTERNS_MESSAGE}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Create a result for when pattern check is skipped (no patterns learned).
+   */
+  private createSkipResult(startTime: number): AnalyzerResult {
+    console.error(`[Craig] ${NO_PATTERNS_MESSAGE}`);
+    return {
+      task: TASK_NAME,
+      success: true,
+      findings: [],
+      actions_taken: [],
+      duration_ms: Date.now() - startTime,
+      error: NO_PATTERNS_MESSAGE,
+    };
+  }
+
+  /**
+   * Build the enforcement prompt for Code Review Guardian.
+   */
+  private buildEnforcePrompt(patterns: PatternSet): string {
+    return [
+      "Review the following code diff for pattern deviations.",
+      "Compare the new code against the repository's established patterns provided below.",
+      "",
+      "For each deviation found, report it as a finding in a markdown table with columns:",
+      "| # | Severity | Category | File:Line | Issue | Source & Justification | Suggested Fix |",
+      "",
+      "Only flag clear deviations from the established patterns.",
+      "Use severity 🟡 Medium for pattern deviations from majority conventions.",
+      "Use severity 🔵 Low for minor style deviations.",
+      `Patterns were learned at: ${patterns.learned_at}`,
+    ].join("\n");
+  }
+
+  /**
+   * Build the context string with patterns + diff for the Guardian.
+   */
+  private buildEnforceContext(patterns: PatternSet, diff: string): string {
+    const patternSummary = this.formatPatternsForContext(patterns);
+
+    return [
+      "## Established Repository Patterns",
+      "",
+      patternSummary,
+      "",
+      "## Code diff to review",
+      "",
+      diff,
+    ].join("\n");
+  }
+
+  /**
+   * Format a PatternSet into a human-readable summary for the prompt context.
+   */
+  private formatPatternsForContext(patterns: PatternSet): string {
+    const sections: string[] = [];
+
+    if (patterns.naming_conventions.length > 0) {
+      sections.push("### Naming Conventions");
+      for (const rule of patterns.naming_conventions) {
+        sections.push(`- **${rule.name}**: ${rule.description} (${rule.frequency})`);
+      }
+    }
+
+    if (patterns.file_structure.length > 0) {
+      sections.push("### File Structure");
+      for (const rule of patterns.file_structure) {
+        sections.push(`- **${rule.name}**: ${rule.description} (${rule.frequency})`);
+      }
+    }
+
+    if (patterns.error_handling.length > 0) {
+      sections.push("### Error Handling");
+      for (const rule of patterns.error_handling) {
+        sections.push(`- **${rule.name}**: ${rule.description} (${rule.frequency})`);
+      }
+    }
+
+    if (patterns.import_conventions.length > 0) {
+      sections.push("### Import Conventions");
+      for (const rule of patterns.import_conventions) {
+        sections.push(`- **${rule.name}**: ${rule.description} (${rule.frequency})`);
+      }
+    }
+
+    return sections.join("\n");
+  }
+
+  /**
+   * Create a failure result from a caught error.
+   */
+  private createErrorResult(error: unknown, startTime: number): AnalyzerResult {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      task: TASK_NAME,
+      success: false,
+      findings: [],
+      actions_taken: [],
+      duration_ms: Date.now() - startTime,
+      error: message,
+    };
+  }
+}

--- a/craig/src/analyzers/pattern-check/pattern-store.port.ts
+++ b/craig/src/analyzers/pattern-check/pattern-store.port.ts
@@ -1,0 +1,48 @@
+/**
+ * PatternStore Port — Interface for pattern persistence.
+ *
+ * Abstracts the storage of learned patterns. The adapter
+ * (FilePatternStore) persists to `.craig-patterns.json`,
+ * but consumers depend only on this port.
+ *
+ * [HEXAGONAL] Inward-facing port. FilePatternStore is the adapter.
+ *
+ * @module analyzers/pattern-check/pattern-store-port
+ */
+
+import type { PatternSet } from "./types.js";
+
+/**
+ * Port interface for pattern storage operations.
+ *
+ * Consumers use this to learn, load, and save repository patterns.
+ * The underlying storage mechanism (file, database, API) is hidden.
+ */
+export interface PatternStorePort {
+  /**
+   * Analyze the repository and learn coding patterns.
+   *
+   * Invokes the Code Review Guardian to analyze the codebase
+   * and extract naming, structure, error handling, and import patterns.
+   *
+   * @param repoPath - Path to the repository root
+   * @returns Learned patterns — never throws
+   */
+  learn(repoPath: string): Promise<PatternSet>;
+
+  /**
+   * Load previously learned patterns from storage.
+   *
+   * @returns The stored PatternSet, or null if no patterns have been learned
+   */
+  load(): Promise<PatternSet | null>;
+
+  /**
+   * Persist a PatternSet to storage.
+   *
+   * Uses atomic writes (write to temp file, then rename) to prevent corruption.
+   *
+   * @param patterns - The PatternSet to persist
+   */
+  save(patterns: PatternSet): Promise<void>;
+}

--- a/craig/src/analyzers/pattern-check/types.ts
+++ b/craig/src/analyzers/pattern-check/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Type definitions for the Pattern Check analyzer component.
+ *
+ * Defines PatternRule, PatternSet, and PatternDeviation — the data models
+ * owned by this component. No other component should define these types.
+ *
+ * @module analyzers/pattern-check/types
+ */
+
+// ---------------------------------------------------------------------------
+// Pattern Rule
+// ---------------------------------------------------------------------------
+
+/** Severity for pattern deviations. */
+export type PatternSeverity = "warning" | "info";
+
+/**
+ * A single learned coding pattern from the repository.
+ *
+ * Represents a convention observed in the existing codebase
+ * (e.g., "error handling uses Result<T> type").
+ */
+export interface PatternRule {
+  /** Short name for the pattern (e.g., "result-type-error-handling"). */
+  readonly name: string;
+
+  /** The observed pattern description or regex. */
+  readonly pattern: string;
+
+  /** Frequency of occurrence (e.g., "15/18 files"). */
+  readonly frequency: string;
+
+  /** How severe a deviation from this pattern is. */
+  readonly severity: PatternSeverity;
+
+  /** Human-readable description of the convention. */
+  readonly description: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern Set
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete set of learned patterns for a repository.
+ *
+ * Persisted to `.craig-patterns.json`. Each category contains
+ * rules that the Pattern Check analyzer enforces on new code.
+ */
+export interface PatternSet {
+  /** Naming conventions (variables, functions, files, classes). */
+  readonly naming_conventions: PatternRule[];
+
+  /** File and directory structure patterns. */
+  readonly file_structure: PatternRule[];
+
+  /** Error handling patterns (Result types, try/catch, custom errors). */
+  readonly error_handling: PatternRule[];
+
+  /** Import conventions (barrel exports, relative vs absolute, ordering). */
+  readonly import_conventions: PatternRule[];
+
+  /** ISO 8601 timestamp when patterns were learned. */
+  readonly learned_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern Deviation
+// ---------------------------------------------------------------------------
+
+/**
+ * A deviation from an established pattern found in new code.
+ *
+ * Generated when the analyzer compares a merge diff against
+ * the learned PatternSet and finds inconsistencies.
+ */
+export interface PatternDeviation {
+  /** Which pattern rule was violated. */
+  readonly rule_name: string;
+
+  /** Which category the deviation belongs to. */
+  readonly category: "naming" | "structure" | "error_handling" | "imports";
+
+  /** File where the deviation was found. */
+  readonly file: string;
+
+  /** Human-readable description of the deviation. */
+  readonly description: string;
+
+  /** Severity of the deviation. */
+  readonly severity: PatternSeverity;
+}


### PR DESCRIPTION
## Summary

Implements the `analyzer-pattern-check` component from issue #14 — learns repository coding conventions and flags deviations in new merge diffs.

## What was implemented

### Shared Analyzer Interface `[HEXAGONAL]`
- `src/analyzers/analyzer.port.ts` — Shared `Analyzer`, `AnalyzerContext`, `AnalyzerResult` interfaces for all future analyzers

### Pattern Check Component `[CLEAN-ARCH]`
- `types.ts` — `PatternRule`, `PatternSet`, `PatternDeviation` data models
- `pattern-store.port.ts` — `PatternStorePort` interface (learn, load, save)
- `file-pattern-store.ts` — `FilePatternStore` adapter (`.craig-patterns.json`, atomic writes, corruption recovery)
- `pattern-check.analyzer.ts` — `PatternCheckAnalyzer` implementing the `Analyzer` interface
- `errors.ts` — `PatternStoreCorruptedError`, `PatternLearningError`
- `index.ts` — Barrel exports

## Acceptance Criteria

- ✅ **AC1**: Learns patterns from repo via Code Review Guardian (naming, structure, error handling, imports)
- ✅ **AC2**: Flags deviations on merge diffs (e.g., 'repo uses Result type (15/18 files), this merge uses try/catch')
- ✅ **AC3**: Returns structured `ParsedFinding[]` for merge review composition
- ✅ **Edge**: No patterns → skips with message 'run `craig_run_task pattern_check` to learn patterns first'
- ✅ **Edge**: Corrupted patterns → re-learns from repo

## Tests `[TDD]`

32 unit tests (14 for FilePatternStore + 18 for PatternCheckAnalyzer):
- All acceptance criteria covered
- Edge cases: no patterns, corrupted file, Copilot failures, empty diff, undefined diff
- Never-throws guarantee verified (execute() always returns AnalyzerResult)
- Schedule trigger behavior verified

```
✓ src/analyzers/pattern-check/__tests__/file-pattern-store.test.ts (14 tests)
✓ src/analyzers/pattern-check/__tests__/pattern-check.analyzer.test.ts (18 tests)
Test Files  2 passed (2)
Tests       32 passed (32)
```

## Files changed

| File | Change | Tests |
|------|--------|-------|
| `src/analyzers/analyzer.port.ts` | Shared Analyzer interface | Used by analyzer tests |
| `src/analyzers/pattern-check/types.ts` | PatternRule, PatternSet types | — |
| `src/analyzers/pattern-check/pattern-store.port.ts` | PatternStorePort interface | — |
| `src/analyzers/pattern-check/file-pattern-store.ts` | FilePatternStore adapter | `__tests__/file-pattern-store.test.ts` |
| `src/analyzers/pattern-check/pattern-check.analyzer.ts` | PatternCheckAnalyzer | `__tests__/pattern-check.analyzer.test.ts` |
| `src/analyzers/pattern-check/errors.ts` | Custom error classes | — |
| `src/analyzers/pattern-check/index.ts` | Barrel export | — |
| `src/analyzers/index.ts` | Analyzers barrel export | — |

Closes #14