### PR TITLE
fix: add MAX_PAGES guard to findExistingIssue pagination

### DIFF
--- a/craig/src/github/__tests__/github.adapter.test.ts
+++ b/craig/src/github/__tests__/github.adapter.test.ts
@@ -261,6 +261,26 @@ describe("GitHubAdapter", () => {
       expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalledTimes(2);
     });
 
+    it("stops paginating after MAX_PAGES (10) and returns null to prevent infinite loops", async () => {
+      // Every page returns 100 results with no match → always requests next page
+      const fullPage = Array.from({ length: 100 }, (_, i) => ({
+        title: `Unrelated issue ${i}`,
+        html_url: `https://github.com/test-owner/test-repo/issues/${i}`,
+        number: i,
+        pull_request: undefined,
+      }));
+
+      mockOctokit.rest.issues.listForRepo.mockResolvedValue({
+        data: fullPage,
+      });
+
+      const result = await adapter.findExistingIssue("Nonexistent issue");
+
+      // Should stop at MAX_PAGES (10) and return null — not loop forever
+      expect(result).toBeNull();
+      expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalledTimes(10);
+    });
+
     it("title matching is case-insensitive", async () => {
       mockOctokit.rest.issues.listForRepo.mockResolvedValue({
         data: [

--- a/craig/src/github/github.adapter.ts
+++ b/craig/src/github/github.adapter.ts
@@ -118,8 +118,7 @@ export class GitHubAdapter implements GitHubPort {
   async findExistingIssue(title: string): Promise<IssueReference | null> {
     let page = 1;
 
-    // eslint-disable-next-line no-constant-condition -- pagination loop
-    while (true) {
+    while (page <= MAX_PAGES) {
       const response = await this.execute(() =>
         this.octokit.rest.issues.listForRepo({
           owner: this.owner,
@@ -143,6 +142,8 @@ export class GitHubAdapter implements GitHubPort {
 
       page++;
     }
+
+    return null;
   }
 
   async listOpenIssues(labels?: string[]): Promise<IssueReference[]> {


### PR DESCRIPTION
## Summary

`findExistingIssue()` used `while(true)` with no upper bound on page count, creating an unbounded pagination loop that could exhaust API rate limits and cause OOM in adversarial conditions.

## Changes

| File | Change |
|------|--------|
| `craig/src/github/github.adapter.ts` | Replaced `while(true)` with `while(page <= MAX_PAGES)`, returns `null` when cap reached |
| `craig/src/github/__tests__/github.adapter.test.ts` | Added regression test verifying pagination stops at 10 pages |

## Details

- **Root cause:** `findExistingIssue()` lacked the same `MAX_PAGES=10` safety guard that `listOpenIssues()` already had
- **Fix:** Changed loop condition from `while(true)` to `while(page <= MAX_PAGES)` and added `return null` after the loop
- **Test:** New test mocks 100-item pages with no match, verifies exactly 10 API calls and `null` return
- **Before fix:** The regression test caused Node.js OOM crash — confirming the vulnerability

## Verification

```
38 tests passed (38) — all existing + 1 new regression test
```

Closes #39