### PR TITLE
fix(craig): harmonize Severity imports to canonical shared/severity.ts

### DIFF
--- a/craig/src/analyzers/coverage-scan/coverage-scan.adapter.ts
+++ b/craig/src/analyzers/coverage-scan/coverage-scan.adapter.ts
@@ -26,7 +26,8 @@ import type {
   ActionTaken,
 } from "../analyzer.types.js";
 import type { CoverageScanDeps } from "./coverage-scan.types.js";
-import type { CoverageGap, Severity } from "../../result-parser/index.js";
+import type { CoverageGap } from "../../result-parser/index.js";
+import type { Severity } from "../../shared/severity.js";
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/craig/src/analyzers/dependency-check/dependency-check.parsers.ts
+++ b/craig/src/analyzers/dependency-check/dependency-check.parsers.ts
@@ -11,7 +11,7 @@
  * @module analyzers/dependency-check
  */
 
-import type { Severity } from "../../state/index.js";
+import type { Severity } from "../../shared/severity.js";
 import type { Vulnerability } from "./dependency-check.types.js";
 
 /* ------------------------------------------------------------------ */

--- a/craig/src/analyzers/dependency-check/dependency-check.types.ts
+++ b/craig/src/analyzers/dependency-check/dependency-check.types.ts
@@ -7,7 +7,7 @@
  * @module analyzers/dependency-check
  */
 
-import type { Severity } from "../../state/index.js";
+import type { Severity } from "../../shared/severity.js";
 
 /* ------------------------------------------------------------------ */
 /*  Package Manager Detection                                          */

--- a/craig/src/analyzers/merge-review/comment-formatter.ts
+++ b/craig/src/analyzers/merge-review/comment-formatter.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ParsedFinding } from "../../result-parser/index.js";
-import type { Severity } from "../../result-parser/index.js";
+import type { Severity } from "../../shared/severity.js";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/craig/src/analyzers/security-scan/security-scan.analyzer.ts
+++ b/craig/src/analyzers/security-scan/security-scan.analyzer.ts
@@ -321,7 +321,7 @@ export function createSecurityScanAnalyzer(deps: SecurityScanDeps): AnalyzerPort
 
       // Map to canonical AnalyzerFinding
       analyzerFindings.push({
-        severity: finding.severity as import("../../shared/severity.js").Severity,
+        severity: finding.severity,
         category: finding.category,
         file: finding.file_line || undefined,
         issue: finding.issue,


### PR DESCRIPTION
## Summary

Harmonizes all analyzer `Severity` imports to use the canonical source (`src/shared/severity.ts`) instead of sibling component re-exports.

## Problem

7 analyzers were built in parallel. After merge, some imported `Severity` from `state/index.js` or `result-parser/index.js` (re-exports) instead of the canonical `shared/severity.js`. While structurally identical (tsc passes), this violates `[CLEAN-ARCH]` — analyzers should depend on shared modules directly, not through sibling adapters.

Additionally, `security-scan` used an unsafe inline type assertion (`as import(...).Severity`).

## Changes

| File | Change |
|------|--------|
| `dependency-check/dependency-check.types.ts` | `state/index.js` → `shared/severity.js` |
| `dependency-check/dependency-check.parsers.ts` | `state/index.js` → `shared/severity.js` |
| `coverage-scan/coverage-scan.adapter.ts` | Split import: `CoverageGap` from result-parser, `Severity` from shared |
| `merge-review/comment-formatter.ts` | `result-parser/index.js` → `shared/severity.js` |
| `security-scan/security-scan.analyzer.ts` | Remove `as import(...).Severity` assertion |

## Verification

- ✅ `npx tsc --noEmit` — zero errors
- ✅ `npm run build` — clean
- ✅ `npm test` — 610/610 tests passing (22 test files)
- ✅ No remaining non-canonical Severity imports in `src/analyzers/`

Closes #43