### PR TITLE
fix(security): sanitize error messages in MCP tool responses

### DIFF
--- a/craig/src/core/__tests__/error-sanitizer.test.ts
+++ b/craig/src/core/__tests__/error-sanitizer.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Unit tests for error sanitizer — written FIRST per TDD.
+ *
+ * Acceptance criteria from issue #41:
+ * - AC1: Known error types map to safe, generic messages (no internals)
+ * - AC2: Unknown errors return a generic "internal error" message
+ * - AC3: Detailed error info is logged to stderr for debugging
+ * - AC4: Safe messages never contain file paths or API details
+ * - AC5: Error codes are granular (not always INTERNAL_ERROR)
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/41
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sanitizeError } from "../error-sanitizer.js";
+import type { SanitizedError } from "../error-sanitizer.js";
+
+// Import all known error classes to test mapping
+import { StateCorruptedError } from "../../state/errors.js";
+import {
+  ConfigNotFoundError,
+  ConfigValidationError,
+  ConfigParseError,
+} from "../../config/config.errors.js";
+import {
+  GitHubRateLimitError,
+  GitHubAuthError,
+  GitHubNotFoundError,
+  GitHubAPIError,
+} from "../../github/github.errors.js";
+import {
+  CopilotSessionError,
+  CopilotTimeoutError,
+  CopilotUnavailableError,
+} from "../../copilot/copilot.errors.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Patterns that must NEVER appear in safe messages. */
+const FORBIDDEN_PATTERNS = [
+  /\/Users\//i,
+  /\/home\//i,
+  /\/tmp\//i,
+  /\.yaml$/i,
+  /\.json$/i,
+  /\.ts$/i,
+  /node_modules/i,
+  /Error\(/i,
+  /at\s+\w+\s+\(/i, // stack trace fragments
+];
+
+function assertNoLeakedInternals(message: string): void {
+  for (const pattern of FORBIDDEN_PATTERNS) {
+    expect(message).not.toMatch(pattern);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC1: Known error types map to safe, generic messages               */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeError — known error types", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("maps StateCorruptedError to a safe state error message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new StateCorruptedError(
+      "/Users/vbomfim/.craig/state.json",
+      new SyntaxError("Unexpected token"),
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "State storage error. Craig will attempt recovery.",
+    );
+    expect(result.code).toBe("STATE_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps ConfigNotFoundError to a safe config message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new ConfigNotFoundError("/Users/vbomfim/.craig/craig.yaml");
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "Configuration not found. Run craig_config to set up.",
+    );
+    expect(result.code).toBe("CONFIG_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps ConfigValidationError to a safe config message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new ConfigValidationError(
+      "Invalid schema: missing field 'repo'",
+      ["repo is required"],
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "Configuration is invalid. Check your craig.yaml.",
+    );
+    expect(result.code).toBe("CONFIG_ERROR");
+  });
+
+  it("maps ConfigParseError to a safe config message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new ConfigParseError(
+      "YAML parse error at line 12: unexpected indent",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe("Configuration file could not be parsed.");
+    expect(result.code).toBe("CONFIG_ERROR");
+  });
+
+  it("maps GitHubRateLimitError to a safe rate limit message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubRateLimitError(new Date("2025-07-15T10:00:00Z"));
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "GitHub API rate limit exceeded. Try again later.",
+    );
+    expect(result.code).toBe("RATE_LIMIT");
+  });
+
+  it("maps GitHubAuthError to a safe auth message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubAuthError(
+      "Bad credentials: token ghp_abc123... is revoked",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "GitHub authentication failed. Check your token.",
+    );
+    expect(result.code).toBe("AUTH_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps GitHubNotFoundError to a safe not-found message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubNotFoundError("repos/vbomfim/private-project");
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "Requested GitHub resource was not found.",
+    );
+    expect(result.code).toBe("NOT_FOUND");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps GitHubAPIError to a safe API error message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubAPIError(
+      500,
+      "Internal Server Error: database connection timeout on shard-3",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe("GitHub API request failed.");
+    expect(result.code).toBe("GITHUB_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps CopilotSessionError to a safe copilot message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new CopilotSessionError(
+      "Session ID abc-123 expired at /tmp/copilot/sessions/abc-123.json",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "Copilot session failed. Retry the operation.",
+    );
+    expect(result.code).toBe("COPILOT_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("maps CopilotTimeoutError to a safe timeout message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new CopilotTimeoutError(30000);
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe("Copilot operation timed out. Try again.");
+    expect(result.code).toBe("TIMEOUT");
+  });
+
+  it("maps CopilotUnavailableError to a safe unavailable message", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new CopilotUnavailableError(
+      "Binary not found at /usr/local/bin/copilot-cli",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe(
+      "Copilot is not available. Check your installation.",
+    );
+    expect(result.code).toBe("COPILOT_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC2: Unknown errors return a generic message                       */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeError — unknown error types", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("returns generic message for a plain Error", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error(
+      "ENOENT: no such file or directory, open '/Users/vbomfim/.craig/secrets.json'",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).toBe("An internal error occurred.");
+    expect(result.code).toBe("INTERNAL_ERROR");
+    assertNoLeakedInternals(result.message);
+  });
+
+  it("returns generic message for a non-Error thrown value", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = sanitizeError("some string error with path /etc/passwd");
+
+    expect(result.message).toBe("An internal error occurred.");
+    expect(result.code).toBe("INTERNAL_ERROR");
+  });
+
+  it("returns generic message for null/undefined thrown values", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(sanitizeError(null).message).toBe("An internal error occurred.");
+    expect(sanitizeError(undefined).message).toBe(
+      "An internal error occurred.",
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC3: Detailed error info is logged to stderr                       */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeError — stderr logging", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("logs full error message to stderr for known errors", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new ConfigNotFoundError("/Users/vbomfim/.craig/craig.yaml");
+
+    sanitizeError(error);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[Craig] ConfigNotFoundError"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/Users/vbomfim/.craig/craig.yaml"),
+    );
+  });
+
+  it("logs full error message to stderr for unknown errors", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("Unexpected failure in module X");
+
+    sanitizeError(error);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[Craig] Error"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unexpected failure in module X"),
+    );
+  });
+
+  it("logs stringified value for non-Error thrown values", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    sanitizeError(42);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[Craig] Non-error thrown: 42"),
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC4: Safe messages never contain file paths or API details         */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeError — no information leakage", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("never leaks file paths from StateCorruptedError", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new StateCorruptedError(
+      "/home/ci/app/.craig/state.json",
+      new Error("parse failed"),
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).not.toContain("/home");
+    expect(result.message).not.toContain(".json");
+    expect(result.message).not.toContain("parse failed");
+  });
+
+  it("never leaks GitHub token fragments from GitHubAuthError", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubAuthError(
+      "Bad credentials for token ghp_A1B2C3D4E5F6",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).not.toContain("ghp_");
+    expect(result.message).not.toContain("Bad credentials");
+    expect(result.message).not.toContain("A1B2C3");
+  });
+
+  it("never leaks server internals from GitHubAPIError", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new GitHubAPIError(
+      503,
+      "Service unavailable: upstream proxy shard-12.internal.github.com timed out",
+    );
+
+    const result = sanitizeError(error);
+
+    expect(result.message).not.toContain("shard");
+    expect(result.message).not.toContain("internal.github.com");
+    expect(result.message).not.toContain("503");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC5: Return type is well-typed                                     */
+/* ------------------------------------------------------------------ */
+
+describe("sanitizeError — return type", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    errorSpy?.mockRestore();
+  });
+
+  it("returns a SanitizedError with message and code fields", () => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result: SanitizedError = sanitizeError(new Error("test"));
+
+    expect(result).toHaveProperty("message");
+    expect(result).toHaveProperty("code");
+    expect(typeof result.message).toBe("string");
+    expect(typeof result.code).toBe("string");
+  });
+});

--- a/craig/src/core/__tests__/tool-handlers.test.ts
+++ b/craig/src/core/__tests__/tool-handlers.test.ts
@@ -390,8 +390,9 @@ describe("craig_digest handler", () => {
 /*  Error handling — tool handlers never throw                         */
 /* ------------------------------------------------------------------ */
 
-describe("error handling — handlers return errors, never throw", () => {
-  it("craig_status returns error object on state failure", async () => {
+describe("error handling — handlers return sanitized errors, never throw", () => {
+  it("craig_status returns sanitized error on state failure", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const state = createMockState();
     vi.mocked(state.get).mockImplementation(() => {
       throw new Error("State corrupted");
@@ -400,11 +401,15 @@ describe("error handling — handlers return errors, never throw", () => {
 
     const result = await handler();
 
-    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("error", "An internal error occurred.");
     expect(result).toHaveProperty("code", "INTERNAL_ERROR");
+    // Verify raw message is NOT leaked
+    expect(result.error).not.toContain("State corrupted");
+    errorSpy.mockRestore();
   });
 
-  it("craig_findings returns error object on state failure", async () => {
+  it("craig_findings returns sanitized error on state failure", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const state = createMockState();
     vi.mocked(state.getFindings).mockImplementation(() => {
       throw new Error("State corrupted");
@@ -413,11 +418,14 @@ describe("error handling — handlers return errors, never throw", () => {
 
     const result = await handler({});
 
-    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("error", "An internal error occurred.");
     expect(result).toHaveProperty("code", "INTERNAL_ERROR");
+    expect(result.error).not.toContain("State corrupted");
+    errorSpy.mockRestore();
   });
 
-  it("craig_config returns error object on config failure", async () => {
+  it("craig_config returns sanitized error on config failure", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const config = createMockConfig();
     vi.mocked(config.get).mockImplementation(() => {
       throw new Error("Config not loaded");
@@ -426,8 +434,10 @@ describe("error handling — handlers return errors, never throw", () => {
 
     const result = await handler({ action: "view" });
 
-    expect(result).toHaveProperty("error");
+    expect(result).toHaveProperty("error", "An internal error occurred.");
     expect(result).toHaveProperty("code", "INTERNAL_ERROR");
+    expect(result.error).not.toContain("Config not loaded");
+    errorSpy.mockRestore();
   });
 });
 

--- a/craig/src/core/error-sanitizer.ts
+++ b/craig/src/core/error-sanitizer.ts
@@ -1,0 +1,178 @@
+/**
+ * Error sanitizer for MCP tool responses.
+ *
+ * Maps known error types to safe, generic messages that don't leak
+ * internal details (file paths, API keys, server internals) to MCP
+ * clients. Detailed error information is logged to stderr for
+ * debugging.
+ *
+ * [SECURITY] — Prevents information disclosure via error messages.
+ * [CLEAN-CODE] — Single function, clear mapping, no side effects
+ *   beyond stderr logging.
+ * [SRP] — Error sanitization is its own concern, separate from
+ *   tool handler logic.
+ *
+ * @module core/error-sanitizer
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/41
+ */
+
+import { StateCorruptedError } from "../state/errors.js";
+import {
+  ConfigNotFoundError,
+  ConfigValidationError,
+  ConfigParseError,
+} from "../config/config.errors.js";
+import {
+  GitHubRateLimitError,
+  GitHubAuthError,
+  GitHubNotFoundError,
+  GitHubAPIError,
+} from "../github/github.errors.js";
+import {
+  CopilotSessionError,
+  CopilotTimeoutError,
+  CopilotUnavailableError,
+} from "../copilot/copilot.errors.js";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+/** Sanitized error returned to MCP clients. */
+export interface SanitizedError {
+  readonly message: string;
+  readonly code: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Error → Safe Message Mapping                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Each entry maps an error constructor to a safe message and error code.
+ * Order doesn't matter — matching is done by instanceof.
+ *
+ * [SOLID/OCP] — Add new mappings here without modifying sanitizeError().
+ */
+type ErrorMapping = readonly {
+  readonly match: new (...args: never[]) => Error;
+  readonly message: string;
+  readonly code: string;
+}[];
+
+const ERROR_MAP: ErrorMapping = [
+  // State errors
+  {
+    match: StateCorruptedError,
+    message: "State storage error. Craig will attempt recovery.",
+    code: "STATE_ERROR",
+  },
+
+  // Config errors
+  {
+    match: ConfigNotFoundError,
+    message: "Configuration not found. Run craig_config to set up.",
+    code: "CONFIG_ERROR",
+  },
+  {
+    match: ConfigValidationError,
+    message: "Configuration is invalid. Check your craig.yaml.",
+    code: "CONFIG_ERROR",
+  },
+  {
+    match: ConfigParseError,
+    message: "Configuration file could not be parsed.",
+    code: "CONFIG_ERROR",
+  },
+
+  // GitHub errors
+  {
+    match: GitHubRateLimitError,
+    message: "GitHub API rate limit exceeded. Try again later.",
+    code: "RATE_LIMIT",
+  },
+  {
+    match: GitHubAuthError,
+    message: "GitHub authentication failed. Check your token.",
+    code: "AUTH_ERROR",
+  },
+  {
+    match: GitHubNotFoundError,
+    message: "Requested GitHub resource was not found.",
+    code: "NOT_FOUND",
+  },
+  {
+    match: GitHubAPIError,
+    message: "GitHub API request failed.",
+    code: "GITHUB_ERROR",
+  },
+
+  // Copilot errors
+  {
+    match: CopilotSessionError,
+    message: "Copilot session failed. Retry the operation.",
+    code: "COPILOT_ERROR",
+  },
+  {
+    match: CopilotTimeoutError,
+    message: "Copilot operation timed out. Try again.",
+    code: "TIMEOUT",
+  },
+  {
+    match: CopilotUnavailableError,
+    message: "Copilot is not available. Check your installation.",
+    code: "COPILOT_ERROR",
+  },
+] as const;
+
+/** Default safe message for unrecognized errors. */
+const DEFAULT_MESSAGE = "An internal error occurred.";
+const DEFAULT_CODE = "INTERNAL_ERROR";
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Sanitize an error for MCP client consumption.
+ *
+ * - Known error types → safe, pre-defined message + granular code.
+ * - Unknown errors → generic "internal error" message.
+ * - All errors are logged to stderr with full detail for debugging.
+ *
+ * [SECURITY] Never returns raw error.message to the MCP client.
+ *
+ * @param error - The caught error (unknown type, as from catch blocks).
+ * @returns A sanitized error with a safe message and error code.
+ */
+export function sanitizeError(error: unknown): SanitizedError {
+  logDetailedError(error);
+
+  if (error instanceof Error) {
+    const mapping = ERROR_MAP.find((entry) => error instanceof entry.match);
+    if (mapping) {
+      return { message: mapping.message, code: mapping.code };
+    }
+  }
+
+  return { message: DEFAULT_MESSAGE, code: DEFAULT_CODE };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Private Helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Log the full error details to stderr for debugging.
+ *
+ * [SECURITY] Stderr is for operators, not MCP clients.
+ * MCP uses stdout for JSON-RPC — stderr is safe for diagnostics.
+ */
+function logDetailedError(error: unknown): void {
+  if (error instanceof Error) {
+    const name = error.name || error.constructor.name;
+    console.error(`[Craig] ${name}: ${error.message}`);
+  } else {
+    console.error(`[Craig] Non-error thrown: ${String(error)}`);
+  }
+}

--- a/craig/src/core/tool-handlers.ts
+++ b/craig/src/core/tool-handlers.ts
@@ -35,6 +35,7 @@ import type {
   DigestParams,
 } from "./core.types.js";
 import { isValidTask } from "./core.types.js";
+import { sanitizeError } from "./error-sanitizer.js";
 
 /* ------------------------------------------------------------------ */
 /*  craig_status                                                       */
@@ -296,14 +297,19 @@ export function createDigestHandler(
 
 /**
  * Create a standard tool error response.
- * Extracts message from Error objects, uses String() for others.
  *
- * [CLEAN-CODE] Error responses are structured, never crash the server.
+ * Sanitizes the error message before returning to the MCP client.
+ * Detailed error information is logged to stderr for debugging.
+ * Raw error.message is never exposed to MCP clients.
+ *
+ * [SECURITY] Prevents information disclosure via error messages.
+ * [CLEAN-CODE] Delegates to sanitizeError() for mapping logic.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/41
  */
 function createToolError(error: unknown): ToolError {
-  const message =
-    error instanceof Error ? error.message : String(error);
-  return { error: message, code: "INTERNAL_ERROR" };
+  const sanitized = sanitizeError(error);
+  return { error: sanitized.message, code: sanitized.code };
 }
 
 /**


### PR DESCRIPTION
## Summary

`createToolError()` was passing raw `error.message` directly to MCP clients. GitHub API errors, config errors, and state errors could leak file paths, token fragments, and server internals.

## Changes

### New: `craig/src/core/error-sanitizer.ts` `[SRP]` `[SECURITY]`
- Maps 11 known error types to safe, generic messages with granular error codes
- Unknown errors return `"An internal error occurred."` with `INTERNAL_ERROR` code
- Detailed errors logged to stderr (operators only, not MCP clients)
- Extensible via `ERROR_MAP` array — add new mappings without changing `sanitizeError()` `[OCP]`

### Error mapping table

| Error Type | Safe Message | Code |
|---|---|---|
| `StateCorruptedError` | State storage error. Craig will attempt recovery. | `STATE_ERROR` |
| `ConfigNotFoundError` | Configuration not found. Run craig_config to set up. | `CONFIG_ERROR` |
| `ConfigValidationError` | Configuration is invalid. Check your craig.yaml. | `CONFIG_ERROR` |
| `ConfigParseError` | Configuration file could not be parsed. | `CONFIG_ERROR` |
| `GitHubRateLimitError` | GitHub API rate limit exceeded. Try again later. | `RATE_LIMIT` |
| `GitHubAuthError` | GitHub authentication failed. Check your token. | `AUTH_ERROR` |
| `GitHubNotFoundError` | Requested GitHub resource was not found. | `NOT_FOUND` |
| `GitHubAPIError` | GitHub API request failed. | `GITHUB_ERROR` |
| `CopilotSessionError` | Copilot session failed. Retry the operation. | `COPILOT_ERROR` |
| `CopilotTimeoutError` | Copilot operation timed out. Try again. | `TIMEOUT` |
| `CopilotUnavailableError` | Copilot is not available. Check your installation. | `COPILOT_ERROR` |
| Unknown `Error` / non-Error | An internal error occurred. | `INTERNAL_ERROR` |

### Modified: `craig/src/core/tool-handlers.ts`
- `createToolError()` now delegates to `sanitizeError()` instead of passing raw `error.message`

### Tests: 21 new + 3 updated
- All 11 known error type mappings tested
- Unknown error types (plain Error, strings, null/undefined)
- Information leakage prevention (file paths, token fragments, server internals)
- Stderr logging verification
- Existing handler error tests updated to verify sanitized messages

## Test Results
```
Test Files  23 passed (23)
Tests       631 passed (631)
```

Closes #41