### PR TITLE
feat(craig): daemon mode with SSE transport

### DIFF
--- a/craig/src/cli/__tests__/parse-args.test.ts
+++ b/craig/src/cli/__tests__/parse-args.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for CLI argument parsing.
+ *
+ * Verifies that parseCliArgs() correctly extracts --daemon and --port
+ * flags from process.argv-style arrays.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/36 — AC1
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseCliArgs, CliParseError } from "../parse-args.js";
+
+/* ------------------------------------------------------------------ */
+/*  AC1: --daemon --port flag parsing                                  */
+/* ------------------------------------------------------------------ */
+
+describe("parseCliArgs", () => {
+  it("returns daemon=false with defaults when no args given", () => {
+    const result = parseCliArgs([]);
+
+    expect(result).toEqual({
+      daemon: false,
+      port: 3001,
+    });
+  });
+
+  it("parses --daemon --port 3001", () => {
+    const result = parseCliArgs(["--daemon", "--port", "3001"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 3001,
+    });
+  });
+
+  it("parses --daemon --port 8080 with custom port", () => {
+    const result = parseCliArgs(["--daemon", "--port", "8080"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 8080,
+    });
+  });
+
+  it("parses --daemon without --port using default port 3001", () => {
+    const result = parseCliArgs(["--daemon"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 3001,
+    });
+  });
+
+  it("parses --port without --daemon", () => {
+    const result = parseCliArgs(["--port", "4000"]);
+
+    expect(result).toEqual({
+      daemon: false,
+      port: 4000,
+    });
+  });
+
+  it("handles --port=VALUE format (equals sign)", () => {
+    const result = parseCliArgs(["--daemon", "--port=9090"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 9090,
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Error cases                                                      */
+  /* ---------------------------------------------------------------- */
+
+  it("throws CliParseError for non-numeric port", () => {
+    expect(() => parseCliArgs(["--port", "abc"])).toThrow(CliParseError);
+    expect(() => parseCliArgs(["--port", "abc"])).toThrow(
+      /Invalid port/,
+    );
+  });
+
+  it("throws CliParseError for port below 1", () => {
+    expect(() => parseCliArgs(["--port", "0"])).toThrow(CliParseError);
+    expect(() => parseCliArgs(["--port", "-1"])).toThrow(CliParseError);
+  });
+
+  it("throws CliParseError for port above 65535", () => {
+    expect(() => parseCliArgs(["--port", "70000"])).toThrow(CliParseError);
+  });
+
+  it("throws CliParseError when --port is last arg with no value", () => {
+    expect(() => parseCliArgs(["--port"])).toThrow(CliParseError);
+  });
+
+  it("ignores unknown flags without crashing", () => {
+    const result = parseCliArgs(["--daemon", "--verbose", "--port", "3001"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 3001,
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Edge cases                                                       */
+  /* ---------------------------------------------------------------- */
+
+  it("handles flags in any order", () => {
+    const result = parseCliArgs(["--port", "5000", "--daemon"]);
+
+    expect(result).toEqual({
+      daemon: true,
+      port: 5000,
+    });
+  });
+
+  it("uses the last --port value when specified multiple times", () => {
+    const result = parseCliArgs(["--port", "3000", "--port", "4000"]);
+
+    expect(result.port).toBe(4000);
+  });
+});

--- a/craig/src/cli/index.ts
+++ b/craig/src/cli/index.ts
@@ -1,0 +1,11 @@
+/**
+ * CLI component — public API barrel export.
+ *
+ * All consumers import from here, never from internals.
+ * This is the component boundary.
+ *
+ * @module cli
+ */
+
+export { parseCliArgs, CliParseError } from "./parse-args.js";
+export type { CliOptions } from "./parse-args.js";

--- a/craig/src/cli/parse-args.ts
+++ b/craig/src/cli/parse-args.ts
@@ -1,0 +1,105 @@
+/**
+ * CLI argument parser for Craig.
+ *
+ * Parses process.argv-style arrays to extract --daemon and --port flags.
+ * Pure function — no side effects, no I/O, fully testable.
+ *
+ * [CLEAN-CODE] Single responsibility: only parses CLI args.
+ * [YAGNI] Only supports the flags we need — no framework dependency.
+ *
+ * @module cli/parse-args
+ */
+
+/** Parsed CLI options. */
+export interface CliOptions {
+  /** Whether to run in daemon mode (SSE transport). */
+  readonly daemon: boolean;
+  /** Port number for the daemon HTTP server. */
+  readonly port: number;
+}
+
+/** Default port for daemon mode. */
+const DEFAULT_PORT = 3001;
+
+/** Minimum valid TCP port. */
+const MIN_PORT = 1;
+
+/** Maximum valid TCP port. */
+const MAX_PORT = 65535;
+
+/**
+ * Error thrown when CLI arguments are invalid.
+ */
+export class CliParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliParseError";
+  }
+}
+
+/**
+ * Parse CLI arguments into typed options.
+ *
+ * Supports:
+ *   --daemon           Enable daemon mode (SSE transport)
+ *   --port <number>    HTTP server port (default: 3001)
+ *   --port=<number>    Alternate syntax with equals sign
+ *
+ * @param argv - Arguments array (typically process.argv.slice(2))
+ * @returns Parsed CLI options
+ * @throws {CliParseError} If port is invalid (non-numeric, out of range)
+ */
+export function parseCliArgs(argv: readonly string[]): CliOptions {
+  let daemon = false;
+  let port = DEFAULT_PORT;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "--daemon") {
+      daemon = true;
+      continue;
+    }
+
+    if (arg === "--port") {
+      const nextArg = argv[i + 1];
+      if (nextArg === undefined || nextArg.startsWith("--")) {
+        throw new CliParseError(
+          "Invalid port: --port requires a numeric value",
+        );
+      }
+      port = validatePort(nextArg);
+      i++; // Skip the value argument
+      continue;
+    }
+
+    if (arg?.startsWith("--port=")) {
+      const value = arg.slice("--port=".length);
+      port = validatePort(value);
+      continue;
+    }
+
+    // Unknown flags are silently ignored for forward compatibility
+  }
+
+  return { daemon, port };
+}
+
+/**
+ * Validate and parse a port string into a number.
+ *
+ * @param value - String representation of the port
+ * @returns Valid port number
+ * @throws {CliParseError} If the value is not a valid port (1–65535)
+ */
+function validatePort(value: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < MIN_PORT || parsed > MAX_PORT) {
+    throw new CliParseError(
+      `Invalid port "${value}": must be an integer between ${MIN_PORT} and ${MAX_PORT}`,
+    );
+  }
+
+  return parsed;
+}

--- a/craig/src/daemon/__tests__/daemon-server.test.ts
+++ b/craig/src/daemon/__tests__/daemon-server.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the daemon HTTP server.
+ *
+ * Tests the HTTP server that provides SSE transport and health
+ * endpoint for Craig's daemon mode.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/36 — AC1, AC2, AC3
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import {
+  createRequestHandler,
+  startDaemonServer,
+  type DaemonServerOptions,
+} from "../daemon-server.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Make an HTTP request to localhost and return status + body.
+ */
+async function httpRequest(
+  port: number,
+  path: string,
+  method = "GET",
+  body?: string,
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path, method, headers: body ? { "content-type": "application/json" } : {} },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+/**
+ * Create a minimal mock McpServer for testing.
+ *
+ * The connect mock calls transport.start() to simulate real MCP behavior.
+ * Without this, SSE connections would hang because the transport never
+ * sends the initial endpoint event.
+ */
+function createMockMcpServer() {
+  return {
+    connect: vi.fn().mockImplementation(async (transport: { start?: () => Promise<void> }) => {
+      if (transport.start) {
+        await transport.start();
+      }
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC: Health endpoint                                                */
+/* ------------------------------------------------------------------ */
+
+describe("daemon server /health endpoint", () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    const mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 }, // port 0 = OS picks random available port
+    );
+    server = result.httpServer;
+    const addr = server.address();
+    port = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("returns 200 with status JSON on GET /health", async () => {
+    const res = await httpRequest(port, "/health");
+
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body) as Record<string, unknown>;
+    expect(body).toHaveProperty("status", "ok");
+    expect(body).toHaveProperty("mode", "daemon");
+    expect(body).toHaveProperty("uptime");
+    expect(typeof body.uptime).toBe("number");
+  });
+
+  it("returns 404 for unknown paths", async () => {
+    const res = await httpRequest(port, "/unknown");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 405 for non-GET on /health", async () => {
+    const res = await httpRequest(port, "/health", "POST");
+
+    expect(res.status).toBe(405);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC: SSE transport                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("daemon server SSE transport", () => {
+  let server: http.Server;
+  let port: number;
+  let mockMcpServer: ReturnType<typeof createMockMcpServer>;
+
+  beforeEach(async () => {
+    mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 },
+    );
+    server = result.httpServer;
+    const addr = server.address();
+    port = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("GET /sse returns SSE content-type and connects MCP server", async () => {
+    // SSE connections don't complete normally (they stream),
+    // so we need to handle this carefully
+    const result = await new Promise<{
+      status: number;
+      headers: http.IncomingHttpHeaders;
+      firstChunk: string;
+    }>((resolve, reject) => {
+      const req = http.get(
+        { hostname: "127.0.0.1", port, path: "/sse" },
+        (res) => {
+          let firstChunk = "";
+          res.once("data", (chunk: Buffer) => {
+            firstChunk = chunk.toString();
+            req.destroy(); // Close connection after first chunk
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              firstChunk,
+            });
+          });
+          // Timeout if no data comes within 2 seconds
+          setTimeout(() => {
+            req.destroy();
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              firstChunk: "",
+            });
+          }, 2000);
+        },
+      );
+      req.on("error", (err) => {
+        // Ignore connection reset errors from our req.destroy()
+        if ((err as NodeJS.ErrnoException).code !== "ECONNRESET") {
+          reject(err);
+        }
+      });
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers["content-type"]).toContain("text/event-stream");
+    // MCP SSE transport sends an endpoint event as the first message
+    expect(result.firstChunk).toContain("event: endpoint");
+    // MCP server should have been connected
+    expect(mockMcpServer.connect).toHaveBeenCalled();
+  });
+
+  it("POST /messages without valid sessionId returns 400", async () => {
+    const res = await httpRequest(
+      port,
+      "/messages?sessionId=nonexistent",
+      "POST",
+      JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC: Request routing (unit test for createRequestHandler)           */
+/* ------------------------------------------------------------------ */
+
+describe("createRequestHandler routing", () => {
+  it("is a function that returns a request handler", () => {
+    const mockMcpServer = createMockMcpServer();
+    const handler = createRequestHandler(
+      mockMcpServer as unknown as Parameters<typeof createRequestHandler>[0],
+    );
+
+    expect(typeof handler).toBe("function");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC: Server lifecycle                                               */
+/* ------------------------------------------------------------------ */
+
+describe("startDaemonServer", () => {
+  it("returns httpServer and shutdown function", async () => {
+    const mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 },
+    );
+
+    expect(result).toHaveProperty("httpServer");
+    expect(result).toHaveProperty("shutdown");
+    expect(typeof result.shutdown).toBe("function");
+
+    // Cleanup
+    await result.shutdown();
+  });
+
+  it("shutdown closes the HTTP server", async () => {
+    const mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 },
+    );
+
+    await result.shutdown();
+
+    // After shutdown, server should not accept connections
+    const addr = result.httpServer.address();
+    expect(addr).toBeNull(); // Server unref'd after close
+  });
+});

--- a/craig/src/daemon/daemon-server.ts
+++ b/craig/src/daemon/daemon-server.ts
@@ -1,0 +1,287 @@
+/**
+ * Daemon HTTP server for Craig — SSE transport + health endpoint.
+ *
+ * Provides an HTTP server that exposes:
+ *   GET  /sse              — SSE transport for MCP clients
+ *   POST /messages          — MCP JSON-RPC message endpoint
+ *   GET  /health            — Liveness check for process managers
+ *
+ * Uses Node.js built-in `http` module — no Express dependency.
+ * The SSE transport comes from @modelcontextprotocol/sdk.
+ *
+ * [HEXAGONAL] This is a transport adapter — translates HTTP to MCP.
+ * [CLEAN-CODE] Small functions, clear request routing.
+ * [SECURITY] Binds to 127.0.0.1 by default (localhost only).
+ *
+ * @module daemon/daemon-server
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type http from "node:http";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+/** Options for starting the daemon server. */
+export interface DaemonServerOptions {
+  /** Port to listen on. Default: 3001. */
+  readonly port: number;
+  /** Hostname to bind to. Default: "127.0.0.1" (localhost only). */
+  readonly hostname?: string;
+}
+
+/** Result of starting the daemon server. */
+export interface DaemonServerResult {
+  /** The underlying Node.js HTTP server instance. */
+  readonly httpServer: http.Server;
+  /** Gracefully shut down the daemon server and all SSE transports. */
+  readonly shutdown: () => Promise<void>;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+/** Default hostname — localhost only for security. */
+const DEFAULT_HOSTNAME = "127.0.0.1";
+
+/** Timestamp when the daemon started, for uptime calculation. */
+let startTime: number = Date.now();
+
+/* ------------------------------------------------------------------ */
+/*  Request Handler Factory                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Create the HTTP request handler that routes to SSE, messages, or health.
+ *
+ * [CLEAN-CODE] Pure routing logic — each path delegates to a focused handler.
+ * [SECURITY] Unknown paths return 404 — no information leakage.
+ *
+ * @param mcpServer - The configured McpServer instance to connect SSE transports to
+ * @returns HTTP request handler function
+ */
+export function createRequestHandler(
+  mcpServer: McpServer,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  /**
+   * Active SSE transports keyed by session ID.
+   * Each SSE connection gets its own transport instance.
+   */
+  const transports = new Map<string, SSEServerTransport>();
+
+  return (req: IncomingMessage, res: ServerResponse): void => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const pathname = url.pathname;
+    const method = req.method ?? "GET";
+
+    // Route: GET /health — Liveness check
+    if (pathname === "/health") {
+      handleHealth(method, res);
+      return;
+    }
+
+    // Route: GET /sse — Establish SSE connection
+    if (pathname === "/sse" && method === "GET") {
+      void handleSseConnection(mcpServer, transports, res);
+      return;
+    }
+
+    // Route: POST /messages — MCP JSON-RPC messages
+    if (pathname === "/messages" && method === "POST") {
+      void handleMessage(transports, req, res, url);
+      return;
+    }
+
+    // Unknown route
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Route Handlers                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Handle GET /health — returns daemon status for liveness probes.
+ *
+ * Used by systemd, launchd, pm2, or Kubernetes to verify Craig is alive.
+ */
+function handleHealth(method: string, res: ServerResponse): void {
+  if (method !== "GET") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Method not allowed" }));
+    return;
+  }
+
+  const uptimeMs = Date.now() - startTime;
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      status: "ok",
+      mode: "daemon",
+      uptime: Math.floor(uptimeMs / 1000),
+      timestamp: new Date().toISOString(),
+    }),
+  );
+}
+
+/**
+ * Handle GET /sse — establish a new SSE connection.
+ *
+ * Creates a new SSEServerTransport per connection, stores it by session ID,
+ * and connects the MCP server to serve tools over this transport.
+ *
+ * [SECURITY] Transports are cleaned up on connection close to prevent leaks.
+ */
+async function handleSseConnection(
+  mcpServer: McpServer,
+  transports: Map<string, SSEServerTransport>,
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    const transport = new SSEServerTransport("/messages", res);
+    transports.set(transport.sessionId, transport);
+
+    // Clean up transport when client disconnects
+    res.on("close", () => {
+      transports.delete(transport.sessionId);
+    });
+
+    await mcpServer.connect(transport);
+  } catch (error: unknown) {
+    console.error(
+      "[Craig] SSE connection failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  }
+}
+
+/**
+ * Handle POST /messages — route MCP JSON-RPC messages to the correct transport.
+ *
+ * The sessionId query parameter identifies which SSE transport to use.
+ * The request body is parsed as JSON and forwarded to the transport.
+ */
+async function handleMessage(
+  transports: Map<string, SSEServerTransport>,
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  const sessionId = url.searchParams.get("sessionId");
+
+  if (!sessionId) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing sessionId query parameter" }));
+    return;
+  }
+
+  const transport = transports.get(sessionId);
+
+  if (!transport) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "No active session for this sessionId" }));
+    return;
+  }
+
+  try {
+    // Parse request body
+    const body = await readRequestBody(req);
+    const parsed: unknown = JSON.parse(body);
+    await transport.handlePostMessage(req, res, parsed);
+  } catch (error: unknown) {
+    console.error(
+      "[Craig] Message handling failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    if (!res.headersSent) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Read the full request body as a string.
+ * [SECURITY] Limits body size to 1MB to prevent memory exhaustion.
+ */
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  const MAX_BODY_SIZE = 1_048_576; // 1MB
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_SIZE) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    });
+
+    req.on("error", reject);
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Server Lifecycle                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Start the daemon HTTP server.
+ *
+ * Creates an HTTP server with SSE transport and health endpoint,
+ * binds to the specified port and hostname, and returns handles
+ * for the server and a shutdown function.
+ *
+ * @param mcpServer - Configured McpServer instance
+ * @param options - Server options (port, hostname)
+ * @returns Server instance and shutdown function
+ */
+export async function startDaemonServer(
+  mcpServer: McpServer,
+  options: DaemonServerOptions,
+): Promise<DaemonServerResult> {
+  const hostname = options.hostname ?? DEFAULT_HOSTNAME;
+  startTime = Date.now();
+
+  const handler = createRequestHandler(mcpServer);
+  const httpServer = createServer(handler);
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(options.port, hostname, () => {
+      httpServer.removeListener("error", reject);
+      resolve();
+    });
+  });
+
+  const shutdown = async (): Promise<void> => {
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+  };
+
+  return { httpServer, shutdown };
+}

--- a/craig/src/daemon/index.ts
+++ b/craig/src/daemon/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Daemon component — public API barrel export.
+ *
+ * All consumers import from here, never from internals.
+ * This is the component boundary.
+ *
+ * @module daemon
+ */
+
+export {
+  startDaemonServer,
+  createRequestHandler,
+} from "./daemon-server.js";
+export type {
+  DaemonServerOptions,
+  DaemonServerResult,
+} from "./daemon-server.js";

--- a/craig/src/index.ts
+++ b/craig/src/index.ts
@@ -3,11 +3,15 @@
  *
  * Bootstraps the Craig MCP server: loads config, initializes state,
  * creates component instances, wires them together, and connects
- * to the stdio transport.
+ * to either stdio transport (default) or daemon mode (SSE transport).
+ *
+ * Usage:
+ *   node dist/index.js                    # Stdio mode (MCP child process)
+ *   node dist/index.js --daemon --port 3001  # Daemon mode (SSE over HTTP)
  *
  * [HEXAGONAL] This is the composition root — the only place where
  * concrete implementations are instantiated and wired together.
- * [SECURITY] Never console.log() — MCP stdio uses stdout for JSON-RPC.
+ * [SECURITY] Never console.log() in stdio mode — stdout is JSON-RPC.
  * All logging goes to stderr via console.error().
  *
  * @module index
@@ -18,47 +22,81 @@ import { ConfigLoader } from "./config/index.js";
 import { FileStateAdapter } from "./state/index.js";
 import { CopilotAdapter } from "./copilot/index.js";
 import { createCraigServer } from "./core/index.js";
+import { parseCliArgs } from "./cli/index.js";
+import { startDaemonServer } from "./daemon/index.js";
 
 /**
  * Bootstrap and start the Craig MCP server.
  *
  * Sequence:
- * 1. Load config from craig.config.yaml
- * 2. Initialize state from .craig-state.json
- * 3. Create component adapters
- * 4. Wire dependencies into MCP server
- * 5. Connect via stdio transport
+ * 1. Parse CLI args to determine transport mode
+ * 2. Load config from craig.config.yaml
+ * 3. Initialize state from .craig-state.json
+ * 4. Create component adapters
+ * 5. Wire dependencies into MCP server
+ * 6a. Stdio mode: connect via StdioServerTransport (default)
+ * 6b. Daemon mode: start HTTP server with SSE transport
  *
  * Exits with code 1 on fatal errors (missing config, etc.).
  */
 async function main(): Promise<void> {
   try {
-    // 1. Load config
+    // 1. Parse CLI args
+    const args = parseCliArgs(process.argv.slice(2));
+
+    // 2. Load config
     const config = new ConfigLoader();
     await config.load();
     const cfg = config.get();
 
-    // [SECURITY] Log to stderr — stdout is for MCP JSON-RPC
+    // [SECURITY] Log to stderr — stdout is for MCP JSON-RPC in stdio mode
     console.error(`[Craig] Starting for repo: ${cfg.repo}`);
 
-    // 2. Initialize state
+    // 3. Initialize state
     const state = new FileStateAdapter(".craig-state.json");
     await state.load();
 
-    // 3. Create Copilot adapter
+    // 4. Create Copilot adapter
     const copilot = new CopilotAdapter({
       defaultModel: cfg.models.default,
       guardiansPath: cfg.guardians.path,
     });
 
-    // 4. Create and configure MCP server
+    // 5. Create and configure MCP server
     const server = createCraigServer({ state, config, copilot });
 
-    // 5. Connect via stdio transport
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
+    if (args.daemon) {
+      // 6b. Daemon mode: SSE transport over HTTP
+      const { shutdown } = await startDaemonServer(server, {
+        port: args.port,
+      });
 
-    console.error("[Craig] MCP server connected via stdio");
+      console.error(
+        `[Craig] Daemon mode: listening on http://127.0.0.1:${args.port}`,
+      );
+      console.error(`[Craig] SSE endpoint: http://127.0.0.1:${args.port}/sse`);
+      console.error(
+        `[Craig] Health check: http://127.0.0.1:${args.port}/health`,
+      );
+
+      // Graceful shutdown on SIGTERM/SIGINT (systemd, pm2, Ctrl+C)
+      const handleShutdown = (): void => {
+        console.error("[Craig] Shutting down daemon...");
+        void shutdown().then(() => {
+          console.error("[Craig] Daemon stopped.");
+          process.exit(0);
+        });
+      };
+
+      process.on("SIGTERM", handleShutdown);
+      process.on("SIGINT", handleShutdown);
+    } else {
+      // 6a. Stdio mode: standard MCP child process transport (default)
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+
+      console.error("[Craig] MCP server connected via stdio");
+    }
   } catch (error: unknown) {
     const message =
       error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Add `--daemon --port <N>` CLI flags to run Craig as a standalone HTTP server using MCP SSE transport instead of stdio. This allows Craig to persist independently of Copilot CLI lifecycle.

**Closes #36**

## What Changed

### New Components
| File | Purpose |
|------|---------|
| `craig/src/cli/parse-args.ts` | CLI argument parser (`--daemon`, `--port`) |
| `craig/src/cli/index.ts` | Barrel export |
| `craig/src/daemon/daemon-server.ts` | HTTP server with SSE transport + `/health` endpoint |
| `craig/src/daemon/index.ts` | Barrel export |

### Modified
| File | Change |
|------|--------|
| `craig/src/index.ts` | Branch between stdio (default) and daemon mode based on CLI args |

## Usage

```bash
# Stdio mode (default — backward compatible)
node craig/dist/index.js

# Daemon mode
node craig/dist/index.js --daemon --port 3001
```

### Daemon Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/sse` | SSE transport for MCP clients |
| POST | `/messages` | MCP JSON-RPC message routing |
| GET | `/health` | Liveness check (systemd/pm2/k8s) |

### MCP Client Config (daemon mode)
```json
{ "type": "sse", "url": "http://localhost:3001/sse" }
```

## Security
- Binds to `127.0.0.1` by default (localhost only)
- 1MB request body limit to prevent memory exhaustion
- SSE transports cleaned up on client disconnect
- No new dependencies — uses `SSEServerTransport` from existing `@modelcontextprotocol/sdk`

## Tests
- **21 new tests** (13 CLI parsing + 8 daemon server)
- **652 total tests passing**, zero regressions
- TypeScript strict mode: ✅ clean