### PR TITLE
feat(craig): PR Monitoring — Auto-Review Pull Requests

### DIFF
--- a/craig/craig.config.yaml
+++ b/craig/craig.config.yaml
@@ -5,6 +5,7 @@ schedule:
   coverage_scan: 0 8 * * *
   tech_debt_audit: 0 9 * * 1
   dependency_check: 0 10 * * 1
+  pr_monitor: 0 */2 * * *
 capabilities:
   merge_review: true
   coverage_gaps: true
@@ -13,6 +14,7 @@ capabilities:
   po_audit: true
   auto_fix: true
   dependency_updates: true
+  pr_monitor: true
 models:
   code_review:
     - claude-opus-4.6

--- a/craig/src/analyzers/index.ts
+++ b/craig/src/analyzers/index.ts
@@ -64,3 +64,10 @@ export {
   parsePipAudit,
   parseCargoAudit,
 } from "./dependency-check/dependency-check.parsers.js";
+export { createPrReviewAnalyzer } from "./pr-review/index.js";
+export type {
+  PrReviewAnalyzerDeps,
+  PrReviewContext,
+} from "./pr-review/pr-review.analyzer.js";
+export { formatPrReviewComment } from "./pr-review/pr-comment-formatter.js";
+export type { PrCommentInput } from "./pr-review/pr-comment-formatter.js";

--- a/craig/src/analyzers/pr-review/__tests__/pr-comment-formatter.test.ts
+++ b/craig/src/analyzers/pr-review/__tests__/pr-comment-formatter.test.ts
@@ -1,0 +1,160 @@
+/**
+ * PR Comment Formatter — Unit Tests
+ *
+ * Tests the pure formatting function for PR review comments.
+ *
+ * [TDD] Written BEFORE implementation.
+ * [CLEAN-CODE] Pure function tests — no mocks needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatPrReviewComment } from "../pr-comment-formatter.js";
+import type { PrCommentInput } from "../pr-comment-formatter.js";
+import type { ParsedFinding } from "../../../result-parser/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createFinding(
+  overrides: Partial<ParsedFinding> = {},
+): ParsedFinding {
+  return {
+    number: 1,
+    severity: "medium",
+    category: "Quality",
+    file_line: "src/app.ts:10",
+    issue: "Test issue",
+    source_justification: "Clean Code",
+    suggested_fix: "Fix it",
+    ...overrides,
+  };
+}
+
+function createInput(
+  overrides: Partial<PrCommentInput> = {},
+): PrCommentInput {
+  return {
+    pr_number: 10,
+    pr_title: "Add feature",
+    head_sha: "abc1234",
+    securityFindings: [],
+    codeReviewFindings: [],
+    securityTimedOut: false,
+    codeReviewTimedOut: false,
+    diffTruncated: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("formatPrReviewComment", () => {
+  describe("Clean comment (no findings)", () => {
+    it("should include PR Review header", () => {
+      const result = formatPrReviewComment(createInput());
+      expect(result).toContain("Craig — PR Review");
+    });
+
+    it("should include PR number", () => {
+      const result = formatPrReviewComment(createInput({ pr_number: 42 }));
+      expect(result).toContain("#42");
+    });
+
+    it("should include head SHA", () => {
+      const result = formatPrReviewComment(createInput({ head_sha: "def5678" }));
+      expect(result).toContain("def5678");
+    });
+
+    it("should show no issues message", () => {
+      const result = formatPrReviewComment(createInput());
+      expect(result).toContain("No issues found");
+    });
+
+    it("should show truncation warning when diff was truncated", () => {
+      const result = formatPrReviewComment(
+        createInput({ diffTruncated: true }),
+      );
+      expect(result).toContain("truncated");
+    });
+  });
+
+  describe("Findings comment", () => {
+    it("should include security findings section when present", () => {
+      const result = formatPrReviewComment(
+        createInput({
+          securityFindings: [
+            createFinding({
+              severity: "critical",
+              issue: "SQL injection",
+            }),
+          ],
+        }),
+      );
+      expect(result).toContain("Security Findings");
+      expect(result).toContain("SQL injection");
+    });
+
+    it("should include code review findings section when present", () => {
+      const result = formatPrReviewComment(
+        createInput({
+          codeReviewFindings: [
+            createFinding({
+              severity: "medium",
+              issue: "Function too long",
+            }),
+          ],
+        }),
+      );
+      expect(result).toContain("Code Review Findings");
+      expect(result).toContain("Function too long");
+    });
+
+    it("should include severity emoji", () => {
+      const result = formatPrReviewComment(
+        createInput({
+          securityFindings: [
+            createFinding({ severity: "critical" }),
+          ],
+        }),
+      );
+      expect(result).toContain("🔴");
+    });
+
+    it("should include summary with severity counts", () => {
+      const result = formatPrReviewComment(
+        createInput({
+          securityFindings: [
+            createFinding({ severity: "critical" }),
+            createFinding({ severity: "high", number: 2 }),
+          ],
+          codeReviewFindings: [
+            createFinding({ severity: "medium" }),
+          ],
+        }),
+      );
+      expect(result).toContain("Summary");
+      expect(result).toContain("1 critical");
+      expect(result).toContain("1 high");
+      expect(result).toContain("1 medium");
+    });
+  });
+
+  describe("Guardian timeout", () => {
+    it("should show timeout message for security guardian", () => {
+      const result = formatPrReviewComment(
+        createInput({ securityTimedOut: true }),
+      );
+      expect(result).toContain("Security Guardian timed out");
+    });
+
+    it("should show timeout message for code review guardian", () => {
+      const result = formatPrReviewComment(
+        createInput({ codeReviewTimedOut: true }),
+      );
+      expect(result).toContain("Code Review Guardian timed out");
+    });
+  });
+});

--- a/craig/src/analyzers/pr-review/__tests__/pr-review.analyzer.test.ts
+++ b/craig/src/analyzers/pr-review/__tests__/pr-review.analyzer.test.ts
@@ -1,0 +1,603 @@
+/**
+ * PrReviewAnalyzer — Unit Tests
+ *
+ * Tests the full PR review orchestration flow:
+ * AC1: Full PR review flow (diff → invoke → parse → review → state)
+ * AC2: Create issues for critical/high findings
+ * AC3: No findings → clean comment
+ * AC4: Guardian timeout handling
+ * AC5: Missing context validation
+ * Edge: Large diff truncation, state update
+ *
+ * [TDD] Written BEFORE implementation. All deps are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createPrReviewAnalyzer } from "../pr-review.analyzer.js";
+import type { CopilotPort } from "../../../copilot/index.js";
+import type { GitHubPort } from "../../../github/index.js";
+import type { StatePort } from "../../../state/index.js";
+import type { ResultParserPort, ParsedReport } from "../../../result-parser/index.js";
+import type { PrReviewContext } from "../pr-review.analyzer.js";
+import type { InvokeResult } from "../../../copilot/index.js";
+
+// ---------------------------------------------------------------------------
+// Mock Factories
+// ---------------------------------------------------------------------------
+
+function createMockCopilot(): CopilotPort {
+  return {
+    invoke: vi.fn().mockResolvedValue({
+      success: true,
+      output: "## Report\nNo issues.",
+      duration_ms: 1500,
+      model_used: "claude-sonnet-4.5",
+    } satisfies InvokeResult),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createMockGitHub(): GitHubPort {
+  return {
+    createIssue: vi.fn().mockResolvedValue({
+      url: "https://github.com/owner/repo/issues/42",
+      number: 42,
+    }),
+    findExistingIssue: vi.fn().mockResolvedValue(null),
+    listOpenIssues: vi.fn().mockResolvedValue([]),
+    createDraftPR: vi.fn().mockResolvedValue({
+      url: "https://github.com/owner/repo/pull/1",
+      number: 1,
+    }),
+    createCommitComment: vi.fn().mockResolvedValue({
+      url: "https://github.com/owner/repo/commit/abc1234#comment",
+    }),
+    getLatestCommits: vi.fn().mockResolvedValue([]),
+    getCommitDiff: vi.fn().mockResolvedValue({
+      sha: "abc1234",
+      files: [],
+    }),
+    getMergeCommits: vi.fn().mockResolvedValue([]),
+    getRateLimit: vi.fn().mockResolvedValue({
+      remaining: 5000,
+      reset: new Date(),
+    }),
+    listOpenPRs: vi.fn().mockResolvedValue([]),
+    getPRDiff: vi.fn().mockResolvedValue("diff --git a/file.ts b/file.ts\n+new code"),
+    postPRReview: vi.fn().mockResolvedValue({
+      id: 1,
+      url: "https://github.com/owner/repo/pull/10#pullrequestreview-1",
+    }),
+    createIssueComment: vi.fn(),
+  };
+}
+
+function createMockState(): StatePort {
+  let reviewedPRs: Record<string, string> = {};
+  return {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockImplementation((key: string) => {
+      if (key === "last_reviewed_prs") return reviewedPRs;
+      return [];
+    }),
+    set: vi.fn().mockImplementation((key: string, value: unknown) => {
+      if (key === "last_reviewed_prs")
+        reviewedPRs = value as Record<string, string>;
+    }),
+    addFinding: vi.fn(),
+    getFindings: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockParser(): ResultParserPort {
+  return {
+    parse: vi.fn().mockReturnValue({
+      guardian: "security",
+      summary: "No issues found.",
+      findings: [],
+      recommended_actions: [],
+      raw: "## Report\nNo issues.",
+    } satisfies ParsedReport),
+  };
+}
+
+function createContext(
+  overrides: Partial<PrReviewContext> = {},
+): PrReviewContext {
+  return {
+    task: "pr_review",
+    taskId: "test-task-id",
+    timestamp: new Date().toISOString(),
+    pr_number: 10,
+    head_sha: "abc1234567890",
+    pr_title: "Add new feature",
+    pr_author: "test-user",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PrReviewAnalyzer", () => {
+  // ─── AC1: Full PR review flow ──────────────────────────────────
+
+  describe("AC1: Full PR review flow", () => {
+    it("should invoke Security + Code Review Guardians in parallel on PR diff", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      expect(copilot.invoke).toHaveBeenCalledTimes(2);
+      expect(copilot.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: "security-guardian",
+        }),
+      );
+      expect(copilot.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: "code-review-guardian",
+        }),
+      );
+    });
+
+    it("should fetch diff from GitHub when not provided in context", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      expect(github.getPRDiff).toHaveBeenCalledWith(10);
+    });
+
+    it("should use pre-fetched diff when provided in context", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(
+        createContext({ diff: "pre-fetched diff content" }),
+      );
+
+      expect(github.getPRDiff).not.toHaveBeenCalled();
+    });
+
+    it("should post a PR review comment via postPRReview", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      expect(github.postPRReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pull_number: 10,
+          event: "COMMENT",
+        }),
+      );
+    });
+
+    it("should return success with summary including PR number", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toContain("#10");
+    });
+
+    it("should update last_reviewed_prs state after successful review", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext({
+        pr_number: 10,
+        head_sha: "abc1234567890",
+      }));
+
+      expect(state.set).toHaveBeenCalledWith(
+        "last_reviewed_prs",
+        expect.objectContaining({ "10": "abc1234567890" }),
+      );
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+
+  // ─── AC2: Create issues for critical/high findings ────────────
+
+  describe("AC2: Create issues for severe findings", () => {
+    it("should create GitHub issues for critical findings", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(parser.parse).mockReturnValue({
+        guardian: "security",
+        summary: "1 critical found",
+        findings: [
+          {
+            number: 1,
+            severity: "critical",
+            category: "[OWASP-A01]",
+            file_line: "src/auth.ts:42",
+            issue: "SQL injection vulnerability",
+            source_justification: "Direct string concatenation in query",
+            suggested_fix: "Use parameterized queries",
+          },
+        ],
+        recommended_actions: [],
+        raw: "",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(github.createIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining("CRITICAL"),
+          labels: expect.arrayContaining(["craig", "pr-review"]),
+        }),
+      );
+      expect(result.actions).toContainEqual(
+        expect.objectContaining({ type: "issue_created" }),
+      );
+    });
+
+    it("should not create issues for medium/low findings", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(parser.parse).mockReturnValue({
+        guardian: "code-review",
+        summary: "1 medium found",
+        findings: [
+          {
+            number: 1,
+            severity: "medium",
+            category: "Design",
+            file_line: "src/utils.ts:10",
+            issue: "Function too long",
+            source_justification: "Exceeds 30 lines",
+            suggested_fix: "Extract helper function",
+          },
+        ],
+        recommended_actions: [],
+        raw: "",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      expect(github.createIssue).not.toHaveBeenCalled();
+    });
+
+    it("should skip issue creation if duplicate exists", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(github.findExistingIssue).mockResolvedValue({
+        url: "https://github.com/owner/repo/issues/99",
+        number: 99,
+      });
+
+      vi.mocked(parser.parse).mockReturnValue({
+        guardian: "security",
+        summary: "1 critical found",
+        findings: [
+          {
+            number: 1,
+            severity: "critical",
+            category: "[OWASP-A01]",
+            file_line: "src/auth.ts:42",
+            issue: "SQL injection",
+            source_justification: "String concat",
+            suggested_fix: "Parameterize",
+          },
+        ],
+        recommended_actions: [],
+        raw: "",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      expect(github.createIssue).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── AC3: No findings → clean comment ─────────────────────────
+
+  describe("AC3: No findings", () => {
+    it("should post clean review when no findings are discovered", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toHaveLength(0);
+      expect(github.postPRReview).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("No issues found"),
+        }),
+      );
+    });
+  });
+
+  // ─── AC4: Guardian timeout handling ────────────────────────────
+
+  describe("AC4: Guardian timeout", () => {
+    it("should handle security guardian timeout gracefully", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(copilot.invoke).mockResolvedValueOnce({
+        success: false,
+        output: "",
+        duration_ms: 300000,
+        model_used: "claude-sonnet-4.5",
+        error: "Timeout after 300000ms",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(result.success).toBe(true);
+      expect(github.postPRReview).toHaveBeenCalled();
+    });
+
+    it("should handle both guardians timing out", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(copilot.invoke).mockResolvedValue({
+        success: false,
+        output: "",
+        duration_ms: 300000,
+        model_used: "claude-sonnet-4.5",
+        error: "Timeout",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toHaveLength(0);
+    });
+  });
+
+  // ─── AC5: Missing context validation ───────────────────────────
+
+  describe("AC5: Missing context validation", () => {
+    it("should return failure when pr_number is missing", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute({
+        task: "pr_review",
+        taskId: "test",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toContain("Missing");
+    });
+  });
+
+  // ─── Edge: Findings stored in state ────────────────────────────
+
+  describe("Edge: State management", () => {
+    it("should store findings in state via addFinding", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(parser.parse).mockReturnValue({
+        guardian: "security",
+        summary: "1 finding",
+        findings: [
+          {
+            number: 1,
+            severity: "medium",
+            category: "Quality",
+            file_line: "src/app.ts:5",
+            issue: "Missing error handling",
+            source_justification: "Clean Code",
+            suggested_fix: "Add try-catch",
+          },
+        ],
+        recommended_actions: [],
+        raw: "",
+      });
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      await analyzer.execute(createContext());
+
+      // Called twice — once after recording findings, once after updating last_reviewed_prs
+      expect(state.addFinding).toHaveBeenCalled();
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Edge: Error handling ──────────────────────────────────────
+
+  describe("Edge: Error handling", () => {
+    it("should return failure result when GitHub API throws", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(github.getPRDiff).mockRejectedValue(new Error("API Error"));
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      const result = await analyzer.execute(createContext());
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toContain("failed");
+      expect(result.summary).toContain("API Error");
+    });
+
+    it("should never throw — always returns AnalyzerResult", async () => {
+      const copilot = createMockCopilot();
+      const github = createMockGitHub();
+      const state = createMockState();
+      const parser = createMockParser();
+
+      vi.mocked(github.getPRDiff).mockRejectedValue(new Error("Unexpected"));
+
+      const analyzer = createPrReviewAnalyzer({
+        copilot,
+        github,
+        state,
+        parser,
+      });
+
+      // Should not throw
+      const result = await analyzer.execute(createContext());
+      expect(result).toBeDefined();
+      expect(typeof result.success).toBe("boolean");
+    });
+  });
+
+  // ─── Analyzer name ────────────────────────────────────────────
+
+  describe("Analyzer identity", () => {
+    it("should have name 'pr_review'", () => {
+      const analyzer = createPrReviewAnalyzer({
+        copilot: createMockCopilot(),
+        github: createMockGitHub(),
+        state: createMockState(),
+        parser: createMockParser(),
+      });
+
+      expect(analyzer.name).toBe("pr_review");
+    });
+  });
+});

--- a/craig/src/analyzers/pr-review/index.ts
+++ b/craig/src/analyzers/pr-review/index.ts
@@ -1,0 +1,13 @@
+/**
+ * PR Review Analyzer — Barrel exports.
+ *
+ * @module analyzers/pr-review
+ */
+
+export { createPrReviewAnalyzer } from "./pr-review.analyzer.js";
+export type {
+  PrReviewAnalyzerDeps,
+  PrReviewContext,
+} from "./pr-review.analyzer.js";
+export { formatPrReviewComment } from "./pr-comment-formatter.js";
+export type { PrCommentInput } from "./pr-comment-formatter.js";

--- a/craig/src/analyzers/pr-review/pr-comment-formatter.ts
+++ b/craig/src/analyzers/pr-review/pr-comment-formatter.ts
@@ -1,0 +1,204 @@
+/**
+ * PR Comment Formatter — Pure function to build PR review comments.
+ *
+ * Formats Guardian findings into a structured GitHub PR review comment.
+ * No side effects, no I/O — takes data in, returns markdown string out.
+ *
+ * [CLEAN-CODE] Pure function — easy to test, easy to rewrite.
+ * [SRP] Single responsibility — formatting only.
+ *
+ * @module analyzers/pr-review
+ */
+
+import type { ParsedFinding } from "../../result-parser/index.js";
+import type { Severity } from "../../shared/severity.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input for building a PR review comment. */
+export interface PrCommentInput {
+  /** PR number. */
+  readonly pr_number: number;
+  /** PR title. */
+  readonly pr_title: string;
+  /** Short SHA of the head commit (first 7 chars). */
+  readonly head_sha: string;
+  /** Security Guardian findings (empty array if timed out). */
+  readonly securityFindings: readonly ParsedFinding[];
+  /** Code Review Guardian findings (empty array if timed out). */
+  readonly codeReviewFindings: readonly ParsedFinding[];
+  /** Whether Security Guardian timed out. */
+  readonly securityTimedOut: boolean;
+  /** Whether Code Review Guardian timed out. */
+  readonly codeReviewTimedOut: boolean;
+  /** Whether the diff was truncated due to size. */
+  readonly diffTruncated: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Severity Constants
+// ---------------------------------------------------------------------------
+
+const SEVERITY_EMOJI: Record<Severity, string> = {
+  critical: "🔴",
+  high: "🟠",
+  medium: "🟡",
+  low: "🔵",
+  info: "ℹ️",
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a PR review comment from parsed findings.
+ *
+ * @param input - Structured data for the comment
+ * @returns Formatted markdown string ready for GitHub PR review
+ */
+export function formatPrReviewComment(input: PrCommentInput): string {
+  const totalFindings =
+    input.securityFindings.length + input.codeReviewFindings.length;
+
+  if (
+    totalFindings === 0 &&
+    !input.securityTimedOut &&
+    !input.codeReviewTimedOut
+  ) {
+    return formatCleanComment(input, input.diffTruncated);
+  }
+
+  return formatFindingsComment(input);
+}
+
+// ---------------------------------------------------------------------------
+// Internal Helpers
+// ---------------------------------------------------------------------------
+
+function formatCleanComment(input: PrCommentInput, diffTruncated: boolean): string {
+  const lines = [
+    "## 🤖 Craig — PR Review",
+    `**PR:** #${input.pr_number} | **Commit:** ${input.head_sha}`,
+    "",
+    "✅ No issues found.",
+  ];
+
+  if (diffTruncated) {
+    lines.push(
+      "",
+      "> ⚠️ Diff was truncated to 5,000 lines. Full review may require manual inspection.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function formatFindingsComment(input: PrCommentInput): string {
+  const guardians = buildGuardianList(input);
+  const lines: string[] = [
+    "## 🤖 Craig — PR Review",
+    `**PR:** #${input.pr_number} | **Commit:** ${input.head_sha} | **Reviewed by:** ${guardians}`,
+    "",
+  ];
+
+  appendSection(
+    lines,
+    "Security Findings",
+    input.securityFindings,
+    input.securityTimedOut,
+    "Security Guardian",
+  );
+
+  appendSection(
+    lines,
+    "Code Review Findings",
+    input.codeReviewFindings,
+    input.codeReviewTimedOut,
+    "Code Review Guardian",
+  );
+
+  appendSummary(lines, [
+    ...input.securityFindings,
+    ...input.codeReviewFindings,
+  ]);
+
+  if (input.diffTruncated) {
+    lines.push(
+      "",
+      "> ⚠️ Diff was truncated to 5,000 lines. Full review may require manual inspection.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function buildGuardianList(input: PrCommentInput): string {
+  const guardians: string[] = [];
+  if (!input.securityTimedOut || input.securityFindings.length > 0) {
+    guardians.push("Security Guardian");
+  }
+  if (!input.codeReviewTimedOut || input.codeReviewFindings.length > 0) {
+    guardians.push("Code Review Guardian");
+  }
+  return guardians.length > 0 ? guardians.join(", ") : "—";
+}
+
+function appendSection(
+  lines: string[],
+  title: string,
+  findings: readonly ParsedFinding[],
+  timedOut: boolean,
+  guardianName: string,
+): void {
+  if (timedOut && findings.length === 0) {
+    lines.push(
+      `### ${title}`,
+      `⚠️ ${guardianName} timed out — run manually with \`craig run security_scan\``,
+      "",
+    );
+    return;
+  }
+
+  if (findings.length === 0) {
+    return;
+  }
+
+  lines.push(`### ${title} (${findings.length})`);
+  lines.push("| Severity | Issue | File | Fix |");
+  lines.push("|----------|-------|------|-----|");
+
+  for (const f of findings) {
+    const emoji = SEVERITY_EMOJI[f.severity] ?? "❓";
+    const severity = f.severity.toUpperCase();
+    const file = f.file_line || "—";
+    const fix = f.suggested_fix || "—";
+    lines.push(`| ${emoji} ${severity} | ${f.issue} | ${file} | ${fix} |`);
+  }
+
+  lines.push("");
+}
+
+function appendSummary(
+  lines: string[],
+  findings: readonly ParsedFinding[],
+): void {
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+
+  for (const f of findings) {
+    counts[f.severity] = (counts[f.severity] ?? 0) + 1;
+  }
+
+  lines.push("### Summary");
+  lines.push(
+    `- 🔴 ${counts.critical} critical | 🟠 ${counts.high} high | 🟡 ${counts.medium} medium | 🔵 ${counts.low} low`,
+  );
+}

--- a/craig/src/analyzers/pr-review/pr-review.analyzer.ts
+++ b/craig/src/analyzers/pr-review/pr-review.analyzer.ts
@@ -1,0 +1,362 @@
+/**
+ * PrReviewAnalyzer — Orchestrates PR Guardian reviews.
+ *
+ * Flow: get PR diff → sanitize → invoke Security + Code Review Guardians
+ *       (parallel) → parse reports → post PR review comment →
+ *       create issues for critical/high → store findings in state →
+ *       update last_reviewed_prs.
+ *
+ * [HEXAGONAL] Depends only on port interfaces — no direct imports of adapters.
+ * [CLEAN-CODE] Never throws — returns { success: false, error } on failure.
+ * [SRP] Orchestration only — formatting delegated to pr-comment-formatter.
+ *
+ * @module analyzers/pr-review
+ */
+
+import type { CopilotPort, InvokeResult } from "../../copilot/index.js";
+import type { GitHubPort } from "../../github/index.js";
+import type { StatePort, Finding } from "../../state/index.js";
+import type {
+  ResultParserPort,
+  ParsedFinding,
+  ParsedReport,
+} from "../../result-parser/index.js";
+import type { AnalyzerPort } from "../analyzer.port.js";
+import type {
+  AnalyzerContext,
+  AnalyzerResult,
+  AnalyzerFinding,
+  ActionTaken,
+} from "../analyzer.types.js";
+import { formatPrReviewComment } from "./pr-comment-formatter.js";
+
+// ---------------------------------------------------------------------------
+// Extended Context — pr-review needs PR info beyond base context
+// ---------------------------------------------------------------------------
+
+/**
+ * Extended context for PR review analysis.
+ *
+ * [CLEAN-ARCH] Extends the shared AnalyzerContext with PR-specific
+ * fields. The PR watcher populates these when dispatching review tasks.
+ */
+export interface PrReviewContext extends AnalyzerContext {
+  /** Pull request number. */
+  readonly pr_number: number;
+  /** Head commit SHA. */
+  readonly head_sha: string;
+  /** PR title. */
+  readonly pr_title: string;
+  /** PR author login. */
+  readonly pr_author: string;
+  /** Pre-fetched diff text (optional — if absent, fetched via GitHubPort). */
+  readonly diff?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of lines in a diff before truncation. */
+const MAX_DIFF_LINES = 5_000;
+
+/** Severity levels that trigger automatic GitHub issue creation. */
+const ISSUE_WORTHY_SEVERITIES = new Set(["critical", "high"]);
+
+// ---------------------------------------------------------------------------
+// Factory Options
+// ---------------------------------------------------------------------------
+
+/** Dependencies required by the PrReviewAnalyzer. */
+export interface PrReviewAnalyzerDeps {
+  readonly copilot: CopilotPort;
+  readonly github: GitHubPort;
+  readonly state: StatePort;
+  readonly parser: ResultParserPort;
+}
+
+// ---------------------------------------------------------------------------
+// Factory Function
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a PrReviewAnalyzer instance.
+ *
+ * [CLEAN-ARCH] Factory function — composition root creates and injects deps.
+ *
+ * @param deps - Port dependencies (copilot, github, state, parser)
+ * @returns AnalyzerPort implementation for PR reviews
+ */
+export function createPrReviewAnalyzer(
+  deps: PrReviewAnalyzerDeps,
+): AnalyzerPort {
+  return {
+    name: "pr_review",
+
+    async execute(context: AnalyzerContext): Promise<AnalyzerResult> {
+      const start = Date.now();
+      const actions: ActionTaken[] = [];
+      const prCtx = context as PrReviewContext;
+
+      try {
+        // Validate input
+        if (!prCtx.pr_number || !prCtx.head_sha) {
+          return failResult(start, "Missing pr_number or head_sha in analyzer context");
+        }
+
+        // Step 1: Get diff
+        const { diff, truncated } = await resolveDiff(prCtx, deps.github);
+
+        // Step 2: Invoke guardians in parallel
+        const [securityResult, codeReviewResult] = await Promise.all([
+          deps.copilot.invoke({
+            agent: "security-guardian",
+            prompt:
+              "Perform a security review of the following pull request diff. Report all findings.",
+            context: diff,
+          }),
+          deps.copilot.invoke({
+            agent: "code-review-guardian",
+            prompt:
+              "Perform a code quality review of the following pull request diff. Report all findings.",
+            context: diff,
+          }),
+        ]);
+
+        // Step 3: Parse reports
+        const securityReport = parseIfSuccessful(
+          securityResult,
+          "security",
+          deps.parser,
+        );
+        const codeReviewReport = parseIfSuccessful(
+          codeReviewResult,
+          "code-review",
+          deps.parser,
+        );
+
+        const allFindings = [
+          ...securityReport.findings,
+          ...codeReviewReport.findings,
+        ];
+
+        // Step 4: Post PR review
+        const comment = formatPrReviewComment({
+          pr_number: prCtx.pr_number,
+          pr_title: prCtx.pr_title,
+          head_sha: prCtx.head_sha.slice(0, 7),
+          securityFindings: securityReport.findings,
+          codeReviewFindings: codeReviewReport.findings,
+          securityTimedOut: !securityResult.success,
+          codeReviewTimedOut: !codeReviewResult.success,
+          diffTruncated: truncated,
+        });
+
+        const reviewRef = await deps.github.postPRReview({
+          pull_number: prCtx.pr_number,
+          body: comment,
+          event: "COMMENT",
+        });
+        actions.push({
+          type: "comment_added",
+          url: reviewRef.url,
+          description: `PR review posted on #${prCtx.pr_number}`,
+        });
+
+        // Step 5: Create issues for critical/high findings
+        const issueActions = await createIssuesForSevereFindings(
+          allFindings,
+          prCtx.pr_number,
+          deps.github,
+        );
+        actions.push(...issueActions);
+
+        // Step 6: Store findings in state
+        await recordFindings(allFindings, prCtx.pr_number, deps.state);
+
+        // Step 7: Update last_reviewed_prs state
+        const reviewedPRs = deps.state.get("last_reviewed_prs");
+        deps.state.set("last_reviewed_prs", {
+          ...reviewedPRs,
+          [String(prCtx.pr_number)]: prCtx.head_sha,
+        });
+        await deps.state.save();
+
+        return {
+          success: true,
+          summary: `PR #${prCtx.pr_number} review: ${allFindings.length} findings`,
+          findings: allFindings.map(toAnalyzerFinding),
+          actions,
+          duration_ms: Date.now() - start,
+        };
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return failResult(start, message, actions);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the diff text from context or GitHub API.
+ * Truncates large diffs to MAX_DIFF_LINES lines.
+ */
+async function resolveDiff(
+  context: PrReviewContext,
+  github: GitHubPort,
+): Promise<{ diff: string; truncated: boolean }> {
+  let diff: string;
+
+  if (context.diff) {
+    diff = context.diff;
+  } else {
+    diff = await github.getPRDiff(context.pr_number);
+  }
+
+  return truncateDiff(diff);
+}
+
+/** Truncate diff to MAX_DIFF_LINES if needed. */
+function truncateDiff(diff: string): { diff: string; truncated: boolean } {
+  const lines = diff.split("\n");
+  if (lines.length <= MAX_DIFF_LINES) {
+    return { diff, truncated: false };
+  }
+  return {
+    diff: lines.slice(0, MAX_DIFF_LINES).join("\n"),
+    truncated: true,
+  };
+}
+
+/** Parse an invoke result if successful; return empty findings if not. */
+function parseIfSuccessful(
+  result: InvokeResult,
+  guardianType: "security" | "code-review",
+  parser: ResultParserPort,
+): ParsedReport {
+  if (result.success) {
+    return parser.parse(result.output, guardianType);
+  }
+  return {
+    guardian: guardianType,
+    summary: "",
+    findings: [],
+    recommended_actions: [],
+    raw: "",
+  };
+}
+
+/** Create GitHub issues for critical/high findings, checking for duplicates. */
+async function createIssuesForSevereFindings(
+  findings: readonly ParsedFinding[],
+  prNumber: number,
+  github: GitHubPort,
+): Promise<ActionTaken[]> {
+  const actions: ActionTaken[] = [];
+
+  for (const finding of findings) {
+    if (!ISSUE_WORTHY_SEVERITIES.has(finding.severity)) {
+      continue;
+    }
+
+    const title = `[Craig] ${finding.severity.toUpperCase()}: ${finding.issue}`;
+    const existing = await github.findExistingIssue(title);
+
+    if (existing) {
+      continue;
+    }
+
+    const issue = await github.createIssue({
+      title,
+      body: buildIssueBody(finding, prNumber),
+      labels: ["craig", "pr-review"],
+    });
+
+    actions.push({
+      type: "issue_created",
+      url: issue.url,
+      description: `Created issue for ${finding.severity} finding: ${finding.issue}`,
+    });
+  }
+
+  return actions;
+}
+
+/** Build the body for a GitHub issue from a finding. */
+function buildIssueBody(finding: ParsedFinding, prNumber: number): string {
+  return [
+    `## Finding`,
+    "",
+    `**Severity:** ${finding.severity.toUpperCase()}`,
+    `**Category:** ${finding.category}`,
+    `**File:** ${finding.file_line || "N/A"}`,
+    `**Source:** PR #${prNumber}`,
+    "",
+    `### Issue`,
+    finding.issue,
+    "",
+    `### Justification`,
+    finding.source_justification,
+    "",
+    `### Suggested Fix`,
+    finding.suggested_fix,
+    "",
+    "---",
+    `_Created automatically by Craig PR review on PR #${prNumber}._`,
+  ].join("\n");
+}
+
+/** Record all findings in the state. */
+async function recordFindings(
+  findings: readonly ParsedFinding[],
+  prNumber: number,
+  state: StatePort,
+): Promise<void> {
+  for (const finding of findings) {
+    const stateFinding: Finding = {
+      id: crypto.randomUUID(),
+      severity: finding.severity,
+      category: finding.category,
+      file: finding.file_line || undefined,
+      issue: finding.issue,
+      source: "pr_review",
+      detected_at: new Date().toISOString(),
+      task: `pr_review_#${prNumber}`,
+    };
+    state.addFinding(stateFinding);
+  }
+
+  await state.save();
+}
+
+/** Map a ParsedFinding to the shared AnalyzerFinding shape. */
+function toAnalyzerFinding(finding: ParsedFinding): AnalyzerFinding {
+  return {
+    severity: finding.severity,
+    category: finding.category,
+    file: finding.file_line || undefined,
+    issue: finding.issue,
+    source: finding.source_justification,
+    suggested_fix: finding.suggested_fix,
+  };
+}
+
+/** Build a failed AnalyzerResult. */
+function failResult(
+  start: number,
+  error: string,
+  actions: readonly ActionTaken[] = [],
+): AnalyzerResult {
+  return {
+    success: false,
+    summary: `PR review failed: ${error}`,
+    findings: [],
+    actions: [...actions],
+    duration_ms: Date.now() - start,
+  };
+}

--- a/craig/src/config/config.schema.ts
+++ b/craig/src/config/config.schema.ts
@@ -102,6 +102,7 @@ export const craigConfigSchema = z
         po_audit: z.boolean().default(true),
         auto_fix: z.boolean().default(true),
         dependency_updates: z.boolean().default(true),
+        pr_monitor: z.boolean().default(false),
       })
       .default({
         merge_review: true,
@@ -111,6 +112,7 @@ export const craigConfigSchema = z
         po_audit: true,
         auto_fix: true,
         dependency_updates: true,
+        pr_monitor: false,
       }),
 
     models: z

--- a/craig/src/github/github.adapter.ts
+++ b/craig/src/github/github.adapter.ts
@@ -15,8 +15,11 @@ import type { GitHubPort } from "./github.port.js";
 import type {
   CreateIssueParams,
   CreatePRParams,
+  CreatePRReviewParams,
   IssueReference,
   PRReference,
+  PRReviewReference,
+  PullRequestInfo,
   CommentReference,
   CommitInfo,
   CommitDiff,
@@ -201,6 +204,65 @@ export class GitHubAdapter implements GitHubPort {
     return {
       url: response.data.html_url,
       number: response.data.number,
+    };
+  }
+
+  async listOpenPRs(): Promise<PullRequestInfo[]> {
+    const allPRs: PullRequestInfo[] = [];
+    let page = 1;
+
+    while (page <= MAX_PAGES) {
+      const response = await this.execute(() =>
+        this.octokit.rest.pulls.list({
+          owner: this.owner,
+          repo: this.repo,
+          state: "open",
+          per_page: PAGE_SIZE,
+          page,
+        }),
+      );
+
+      const prs = response.data.map(mapPullRequest);
+      allPRs.push(...prs);
+
+      if (response.data.length < PAGE_SIZE) {
+        break;
+      }
+
+      page++;
+    }
+
+    return allPRs;
+  }
+
+  async getPRDiff(pullNumber: number): Promise<string> {
+    const response = await this.execute(() =>
+      this.octokit.rest.pulls.get({
+        owner: this.owner,
+        repo: this.repo,
+        pull_number: pullNumber,
+        mediaType: { format: "diff" },
+      }),
+    );
+
+    // When using diff media type, data is the raw diff string
+    return response.data as unknown as string;
+  }
+
+  async postPRReview(params: CreatePRReviewParams): Promise<PRReviewReference> {
+    const response = await this.execute(() =>
+      this.octokit.rest.pulls.createReview({
+        owner: this.owner,
+        repo: this.repo,
+        pull_number: params.pull_number,
+        body: params.body,
+        event: params.event,
+      }),
+    );
+
+    return {
+      id: response.data.id,
+      url: response.data.html_url,
     };
   }
 
@@ -462,4 +524,26 @@ interface GitHubDiffFileItem {
   additions: number;
   deletions: number;
   patch?: string;
+}
+
+interface GitHubPullRequestItem {
+  number: number;
+  title: string;
+  head: { sha: string; ref: string };
+  base: { ref: string };
+  user: { login: string } | null;
+  html_url: string;
+}
+
+/** Map a GitHub API pull request to our PullRequestInfo type. */
+function mapPullRequest(pr: GitHubPullRequestItem): PullRequestInfo {
+  return {
+    number: pr.number,
+    title: pr.title,
+    head_sha: pr.head.sha,
+    head_ref: pr.head.ref,
+    base_ref: pr.base.ref,
+    author: pr.user?.login ?? "unknown",
+    url: pr.html_url,
+  };
 }

--- a/craig/src/github/github.port.ts
+++ b/craig/src/github/github.port.ts
@@ -11,8 +11,11 @@
 import type {
   CreateIssueParams,
   CreatePRParams,
+  CreatePRReviewParams,
   IssueReference,
   PRReference,
+  PRReviewReference,
+  PullRequestInfo,
   CommentReference,
   CommitInfo,
   CommitDiff,
@@ -28,6 +31,9 @@ export interface GitHubPort {
 
   // Pull Requests
   createDraftPR(params: CreatePRParams): Promise<PRReference>;
+  listOpenPRs(): Promise<PullRequestInfo[]>;
+  getPRDiff(pullNumber: number): Promise<string>;
+  postPRReview(params: CreatePRReviewParams): Promise<PRReviewReference>;
 
   // Review Comments
   createCommitComment(sha: string, body: string): Promise<CommentReference>;

--- a/craig/src/github/github.types.ts
+++ b/craig/src/github/github.types.ts
@@ -67,3 +67,43 @@ export interface RateLimitInfo {
   readonly remaining: number;
   readonly reset: Date;
 }
+
+// ---------------------------------------------------------------------------
+// Pull Request Types (PR Monitoring — Issue #33)
+// ---------------------------------------------------------------------------
+
+/** Represents an open pull request with metadata for monitoring. */
+export interface PullRequestInfo {
+  /** PR number. */
+  readonly number: number;
+  /** PR title. */
+  readonly title: string;
+  /** Head branch SHA (latest commit). */
+  readonly head_sha: string;
+  /** Head branch name. */
+  readonly head_ref: string;
+  /** Base branch name. */
+  readonly base_ref: string;
+  /** PR author login. */
+  readonly author: string;
+  /** PR HTML URL. */
+  readonly url: string;
+}
+
+/** Parameters for posting a PR review. */
+export interface CreatePRReviewParams {
+  /** PR number to review. */
+  readonly pull_number: number;
+  /** Review body (markdown). */
+  readonly body: string;
+  /** Review event type. */
+  readonly event: "COMMENT" | "APPROVE" | "REQUEST_CHANGES";
+}
+
+/** Reference to a posted PR review. */
+export interface PRReviewReference {
+  /** Review ID. */
+  readonly id: number;
+  /** HTML URL of the review. */
+  readonly url: string;
+}

--- a/craig/src/github/index.ts
+++ b/craig/src/github/index.ts
@@ -10,8 +10,11 @@ export type { GitHubPort } from "./github.port.js";
 export type {
   CreateIssueParams,
   CreatePRParams,
+  CreatePRReviewParams,
   IssueReference,
   PRReference,
+  PRReviewReference,
+  PullRequestInfo,
   CommentReference,
   CommitInfo,
   CommitDiff,

--- a/craig/src/pr-watcher/__tests__/pr-watcher.adapter.test.ts
+++ b/craig/src/pr-watcher/__tests__/pr-watcher.adapter.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Unit tests for PrWatcherAdapter.
+ *
+ * Tests are organized by acceptance criteria from issue #33.
+ * All tests mock GitHubPort and StatePort — no real API calls.
+ *
+ * AC1: New PR → emit event
+ * AC2: PR with new commits → re-emit event
+ * AC3: PR monitoring disabled → skip polling
+ * AC4: PR already reviewed at current SHA → skip
+ *
+ * @see [TDD] — Tests written first, implementation second
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PrWatcherAdapter } from "../pr-watcher.adapter.js";
+import type { PrEvent, PrHandler } from "../pr-watcher.types.js";
+import type { GitHubPort } from "../../github/index.js";
+import type { StatePort } from "../../state/index.js";
+import type { CraigConfig } from "../../config/index.js";
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+function createMockGitHub(): GitHubPort {
+  return {
+    createIssue: vi.fn(),
+    findExistingIssue: vi.fn(),
+    listOpenIssues: vi.fn(),
+    createDraftPR: vi.fn(),
+    createCommitComment: vi.fn(),
+    getLatestCommits: vi.fn(),
+    getCommitDiff: vi.fn(),
+    getMergeCommits: vi.fn().mockResolvedValue([]),
+    getRateLimit: vi.fn(),
+    listOpenPRs: vi.fn().mockResolvedValue([]),
+    getPRDiff: vi.fn().mockResolvedValue(""),
+    postPRReview: vi.fn().mockResolvedValue({ id: 1, url: "https://github.com/review/1" }),
+    createIssueComment: vi.fn(),
+  };
+}
+
+function createMockState(
+  reviewedPRs: Record<string, string> = {},
+): StatePort {
+  let storedReviewedPRs = { ...reviewedPRs };
+  return {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockImplementation((key: string) => {
+      if (key === "last_reviewed_prs") return storedReviewedPRs;
+      return undefined;
+    }),
+    set: vi.fn().mockImplementation((key: string, value: unknown) => {
+      if (key === "last_reviewed_prs")
+        storedReviewedPRs = value as Record<string, string>;
+    }),
+    addFinding: vi.fn(),
+    getFindings: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockConfig(overrides?: Partial<CraigConfig>): CraigConfig {
+  return {
+    repo: "test-owner/test-repo",
+    branch: "main",
+    schedule: { merge_monitor: "on_push" },
+    capabilities: {
+      merge_review: true,
+      coverage_gaps: true,
+      bug_detection: true,
+      pattern_enforcement: true,
+      po_audit: true,
+      auto_fix: true,
+      dependency_updates: true,
+      pr_monitor: true,
+    },
+    models: { default: "claude-sonnet-4.5" },
+    autonomy: {
+      create_issues: true,
+      create_draft_prs: true,
+      auto_merge: false as const,
+    },
+    guardians: { path: "~/.copilot/" },
+    ...overrides,
+  };
+}
+
+function createPR(
+  number: number,
+  headSha: string,
+  title = `PR #${number}`,
+) {
+  return {
+    number,
+    title,
+    head_sha: headSha,
+    head_ref: `feature-${number}`,
+    base_ref: "main",
+    author: "test-user",
+    url: `https://github.com/test/repo/pull/${number}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PrWatcherAdapter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ─── Lifecycle ─────────────────────────────────────────────────
+
+  describe("Lifecycle", () => {
+    it("should start and report isRunning=true", () => {
+      const watcher = new PrWatcherAdapter({
+        github: createMockGitHub(),
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.start();
+      expect(watcher.isRunning()).toBe(true);
+      watcher.stop();
+    });
+
+    it("should stop and report isRunning=false", () => {
+      const watcher = new PrWatcherAdapter({
+        github: createMockGitHub(),
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.start();
+      watcher.stop();
+      expect(watcher.isRunning()).toBe(false);
+    });
+
+    it("should be idempotent — multiple start() calls are safe", () => {
+      const watcher = new PrWatcherAdapter({
+        github: createMockGitHub(),
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.start();
+      watcher.start();
+      expect(watcher.isRunning()).toBe(true);
+      watcher.stop();
+    });
+
+    it("should be idempotent — multiple stop() calls are safe", () => {
+      const watcher = new PrWatcherAdapter({
+        github: createMockGitHub(),
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.stop();
+      watcher.stop();
+      expect(watcher.isRunning()).toBe(false);
+    });
+  });
+
+  // ─── AC1: New PR → emit event ─────────────────────────────────
+
+  describe("AC1: New PR detected", () => {
+    it("should emit PrEvent for a new PR not in last_reviewed_prs", async () => {
+      const github = createMockGitHub();
+      const state = createMockState({}); // no reviewed PRs
+      const pr = createPR(42, "abc1234");
+      vi.mocked(github.listOpenPRs).mockResolvedValue([pr]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state,
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      // Advance past the poll interval
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pr_number: 42,
+          head_sha: "abc1234",
+          title: "PR #42",
+        }),
+      );
+
+      watcher.stop();
+    });
+
+    it("should emit events for multiple new PRs", async () => {
+      const github = createMockGitHub();
+      const state = createMockState({});
+      vi.mocked(github.listOpenPRs).mockResolvedValue([
+        createPR(1, "sha-1"),
+        createPR(2, "sha-2"),
+        createPR(3, "sha-3"),
+      ]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state,
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      watcher.stop();
+    });
+  });
+
+  // ─── AC2: PR with new commits → re-emit event ─────────────────
+
+  describe("AC2: PR with new commits", () => {
+    it("should emit event when head_sha changes (new commits pushed)", async () => {
+      const github = createMockGitHub();
+      const state = createMockState({ "42": "old-sha" }); // PR 42 was reviewed at old-sha
+      const pr = createPR(42, "new-sha"); // now at new-sha
+      vi.mocked(github.listOpenPRs).mockResolvedValue([pr]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state,
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pr_number: 42,
+          head_sha: "new-sha",
+        }),
+      );
+
+      watcher.stop();
+    });
+  });
+
+  // ─── AC3: PR monitoring disabled → skip ────────────────────────
+
+  describe("AC3: PR monitoring disabled", () => {
+    it("should not start polling when pr_monitor is false", async () => {
+      const github = createMockGitHub();
+      const config = createMockConfig({
+        capabilities: {
+          merge_review: true,
+          coverage_gaps: true,
+          bug_detection: true,
+          pattern_enforcement: true,
+          po_audit: true,
+          auto_fix: true,
+          dependency_updates: true,
+          pr_monitor: false,
+        },
+      });
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state: createMockState(),
+        config,
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      expect(watcher.isRunning()).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(github.listOpenPRs).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+  });
+
+  // ─── AC4: PR already reviewed at current SHA → skip ────────────
+
+  describe("AC4: Already reviewed PR skipped", () => {
+    it("should not emit event when PR is already reviewed at same SHA", async () => {
+      const github = createMockGitHub();
+      const state = createMockState({ "42": "same-sha" });
+      const pr = createPR(42, "same-sha");
+      vi.mocked(github.listOpenPRs).mockResolvedValue([pr]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state,
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler).not.toHaveBeenCalled();
+      watcher.stop();
+    });
+
+    it("should skip reviewed PRs but emit for new ones in same poll", async () => {
+      const github = createMockGitHub();
+      const state = createMockState({ "42": "reviewed-sha" });
+      vi.mocked(github.listOpenPRs).mockResolvedValue([
+        createPR(42, "reviewed-sha"), // already reviewed
+        createPR(43, "new-pr-sha"),   // new PR
+      ]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state,
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ pr_number: 43 }),
+      );
+
+      watcher.stop();
+    });
+  });
+
+  // ─── Error handling ────────────────────────────────────────────
+
+  describe("Error handling", () => {
+    it("should continue polling after an API error", async () => {
+      const github = createMockGitHub();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      vi.mocked(github.listOpenPRs)
+        .mockRejectedValueOnce(new Error("API error"))
+        .mockResolvedValueOnce([createPR(1, "sha-1")]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      // First poll fails
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler).not.toHaveBeenCalled();
+
+      // Second poll succeeds
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      watcher.stop();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("should warn after consecutive failures", async () => {
+      const github = createMockGitHub();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      vi.mocked(github.listOpenPRs).mockRejectedValue(new Error("Persistent failure"));
+
+      const watcher = new PrWatcherAdapter({
+        github,
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.start();
+
+      // Advance through 3 consecutive failures
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("consecutive API failures"),
+      );
+
+      watcher.stop();
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  // ─── Handler management ────────────────────────────────────────
+
+  describe("Handler management", () => {
+    it("should call all registered handlers for each event", async () => {
+      const github = createMockGitHub();
+      vi.mocked(github.listOpenPRs).mockResolvedValue([createPR(1, "sha-1")]);
+
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler1);
+      watcher.onPr(handler2);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+
+      watcher.stop();
+    });
+  });
+
+  // ─── Polling behavior ─────────────────────────────────────────
+
+  describe("Polling behavior", () => {
+    it("should not poll when no open PRs exist", async () => {
+      const github = createMockGitHub();
+      vi.mocked(github.listOpenPRs).mockResolvedValue([]);
+
+      const handler = vi.fn();
+      const watcher = new PrWatcherAdapter({
+        github,
+        state: createMockState(),
+        config: createMockConfig(),
+        pollIntervalMs: 100,
+      });
+
+      watcher.onPr(handler);
+      watcher.start();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(github.listOpenPRs).toHaveBeenCalledTimes(1);
+      expect(handler).not.toHaveBeenCalled();
+
+      watcher.stop();
+    });
+  });
+});

--- a/craig/src/pr-watcher/index.ts
+++ b/craig/src/pr-watcher/index.ts
@@ -1,0 +1,13 @@
+/**
+ * PR Watcher component — public API barrel export.
+ *
+ * All consumers import from this file, never from internals.
+ * This is the component boundary.
+ *
+ * @module pr-watcher
+ */
+
+export { PrWatcherAdapter } from "./pr-watcher.adapter.js";
+export type { PrWatcherPort } from "./pr-watcher.port.js";
+export type { PrEvent, PrHandler } from "./pr-watcher.types.js";
+export type { PrWatcherOptions } from "./pr-watcher.adapter.js";

--- a/craig/src/pr-watcher/pr-watcher.adapter.ts
+++ b/craig/src/pr-watcher/pr-watcher.adapter.ts
@@ -1,0 +1,218 @@
+/**
+ * PrWatcherAdapter — polling-based implementation of PrWatcherPort.
+ *
+ * Polls for open PRs at a regular interval. Compares head SHAs
+ * against `last_reviewed_prs` from State and emits PrEvent
+ * for each new or updated PR detected.
+ *
+ * @see [HEXAGONAL] — Adapter implements the PrWatcherPort interface
+ * @see [CLEAN-CODE] — Small functions, clear error handling
+ * @see [SOLID/SRP] — Only detects PRs needing review; does not review them
+ * @module pr-watcher/adapter
+ */
+
+import type { PrWatcherPort } from "./pr-watcher.port.js";
+import type { PrEvent, PrHandler } from "./pr-watcher.types.js";
+import type { GitHubPort, PullRequestInfo } from "../github/index.js";
+import type { StatePort } from "../state/index.js";
+import type { CraigConfig } from "../config/index.js";
+
+/** Default polling interval: 120 seconds (conservative for PR polling). */
+const DEFAULT_POLL_INTERVAL_MS = 120_000;
+
+/** Number of consecutive failures before logging a warning. */
+const CONSECUTIVE_FAILURE_THRESHOLD = 3;
+
+/** Options for constructing a PrWatcherAdapter. */
+export interface PrWatcherOptions {
+  readonly github: GitHubPort;
+  readonly state: StatePort;
+  readonly config: CraigConfig;
+  /** Polling interval in milliseconds. Defaults to 120000 (120s). */
+  readonly pollIntervalMs?: number;
+}
+
+export class PrWatcherAdapter implements PrWatcherPort {
+  private readonly github: GitHubPort;
+  private readonly state: StatePort;
+  private readonly config: CraigConfig;
+  private readonly pollIntervalMs: number;
+  private readonly handlers: PrHandler[] = [];
+
+  private timerId: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+  private consecutiveFailures = 0;
+  private polling = false;
+  /** Generation counter to prevent duplicate timer chains on rapid start/stop/start. */
+  private generation = 0;
+
+  constructor(options: PrWatcherOptions) {
+    this.github = options.github;
+    this.state = options.state;
+    this.config = options.config;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  // ─── Lifecycle ──────────────────────────────────────────────────
+
+  /**
+   * Start polling for PRs to review.
+   * Idempotent — calling start() when already running is a no-op.
+   * No-op if pr_monitor is disabled in config.
+   */
+  start(): void {
+    if (this.running) {
+      return;
+    }
+
+    if (!this.config.capabilities.pr_monitor) {
+      return;
+    }
+
+    this.running = true;
+    this.generation++;
+    this.schedulePoll();
+  }
+
+  /**
+   * Stop polling for PRs.
+   * Idempotent — calling stop() when already stopped is a no-op.
+   */
+  stop(): void {
+    if (this.timerId !== null) {
+      clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+    this.running = false;
+  }
+
+  /**
+   * Register a handler to be called for each PR needing review.
+   */
+  onPr(handler: PrHandler): void {
+    this.handlers.push(handler);
+  }
+
+  /**
+   * Whether the watcher is currently polling.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ─── Private: Polling ───────────────────────────────────────────
+
+  /**
+   * Schedule the next poll cycle using setTimeout.
+   * Uses setTimeout instead of setInterval to prevent overlapping polls.
+   * Captures generation to prevent duplicate timer chains on rapid start/stop/start.
+   */
+  private schedulePoll(): void {
+    const currentGeneration = this.generation;
+    this.timerId = setTimeout(async () => {
+      await this.executePoll();
+      if (this.running && this.generation === currentGeneration) {
+        this.schedulePoll();
+      }
+    }, this.pollIntervalMs);
+  }
+
+  /**
+   * Execute a single poll cycle.
+   * Fetches open PRs, compares against state, emits events for new/updated PRs.
+   */
+  private async executePoll(): Promise<void> {
+    if (this.polling) {
+      return; // Prevent overlapping polls
+    }
+
+    this.polling = true;
+    try {
+      await this.pollForPRs();
+      this.consecutiveFailures = 0;
+    } catch (error: unknown) {
+      this.handlePollError(error);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  // ─── Private: PR Detection ─────────────────────────────────────
+
+  /**
+   * Poll for open PRs and emit events for those needing review.
+   *
+   * A PR needs review when:
+   * 1. It is not in last_reviewed_prs (new PR), or
+   * 2. Its head_sha differs from the stored SHA (new commits pushed)
+   */
+  private async pollForPRs(): Promise<void> {
+    const openPRs = await this.github.listOpenPRs();
+    const reviewedPRs = this.state.get("last_reviewed_prs");
+
+    const prsNeedingReview = this.filterPRsNeedingReview(openPRs, reviewedPRs);
+
+    for (const pr of prsNeedingReview) {
+      const event = this.toPrEvent(pr);
+      await this.emitPr(event);
+    }
+  }
+
+  /**
+   * Filter open PRs to only those that need review.
+   */
+  private filterPRsNeedingReview(
+    openPRs: PullRequestInfo[],
+    reviewedPRs: Record<string, string>,
+  ): PullRequestInfo[] {
+    return openPRs.filter((pr) => {
+      const lastReviewedSha = reviewedPRs[String(pr.number)];
+      // New PR or new commits since last review
+      return lastReviewedSha !== pr.head_sha;
+    });
+  }
+
+  /**
+   * Convert a PullRequestInfo to a PrEvent.
+   */
+  private toPrEvent(pr: PullRequestInfo): PrEvent {
+    return {
+      pr_number: pr.number,
+      title: pr.title,
+      head_sha: pr.head_sha,
+      head_ref: pr.head_ref,
+      base_ref: pr.base_ref,
+      author: pr.author,
+      url: pr.url,
+    };
+  }
+
+  /**
+   * Emit a PrEvent to all registered handlers.
+   */
+  private async emitPr(event: PrEvent): Promise<void> {
+    for (const handler of this.handlers) {
+      await handler(event);
+    }
+  }
+
+  // ─── Private: Error Handling ────────────────────────────────────
+
+  /**
+   * Handle poll errors: log, track consecutive failures, warn if threshold.
+   */
+  private handlePollError(error: unknown): void {
+    this.consecutiveFailures++;
+
+    console.error(
+      "[Craig] PR watcher poll error:",
+      error instanceof Error ? error : new Error(String(error)),
+    );
+
+    if (this.consecutiveFailures >= CONSECUTIVE_FAILURE_THRESHOLD) {
+      console.warn(
+        `[Craig] PR watcher: ${this.consecutiveFailures} consecutive API failures. Polling continues but may indicate a persistent issue.`,
+      );
+    }
+  }
+}

--- a/craig/src/pr-watcher/pr-watcher.port.ts
+++ b/craig/src/pr-watcher/pr-watcher.port.ts
@@ -1,0 +1,46 @@
+/**
+ * PrWatcherPort — the inward-facing interface for the PR Watcher.
+ *
+ * All consumers depend on this port, never on the adapter implementation.
+ * This boundary ensures the watcher is rewritable without changing
+ * any downstream component.
+ *
+ * @see [HEXAGONAL] — Ports & Adapters pattern
+ * @module pr-watcher/port
+ */
+
+import type { PrHandler } from "./pr-watcher.types.js";
+
+/**
+ * Port for the PR watcher lifecycle and event subscription.
+ *
+ * The watcher polls for open PRs at a regular interval,
+ * compares head SHAs against last_reviewed_prs state, and emits
+ * PrEvent for each new or updated PR detected.
+ */
+export interface PrWatcherPort {
+  /**
+   * Start polling for PRs to review.
+   * Idempotent — calling start() when already running is a no-op.
+   */
+  start(): void;
+
+  /**
+   * Stop polling for PRs.
+   * Idempotent — calling stop() when already stopped is a no-op.
+   */
+  stop(): void;
+
+  /**
+   * Register a handler to be called for each PR needing review.
+   * Multiple handlers can be registered — all are called in order.
+   *
+   * @param handler - Callback invoked with a PrEvent for each PR needing review
+   */
+  onPr(handler: PrHandler): void;
+
+  /**
+   * Whether the watcher is currently polling.
+   */
+  isRunning(): boolean;
+}

--- a/craig/src/pr-watcher/pr-watcher.types.ts
+++ b/craig/src/pr-watcher/pr-watcher.types.ts
@@ -1,0 +1,36 @@
+/**
+ * Type definitions for the PR Watcher component.
+ *
+ * Defines the PrEvent structure emitted when new or updated PRs
+ * are detected during polling.
+ *
+ * @module pr-watcher/types
+ */
+
+/**
+ * Represents a pull request that needs review.
+ *
+ * Emitted via the `onPr` callback when the watcher detects
+ * new PRs or new commits on existing PRs.
+ */
+export interface PrEvent {
+  /** Pull request number. */
+  readonly pr_number: number;
+  /** Pull request title. */
+  readonly title: string;
+  /** Head commit SHA that triggered this event. */
+  readonly head_sha: string;
+  /** Head branch name. */
+  readonly head_ref: string;
+  /** Base branch name. */
+  readonly base_ref: string;
+  /** PR author login. */
+  readonly author: string;
+  /** PR HTML URL. */
+  readonly url: string;
+}
+
+/**
+ * Handler function invoked when a PR needs review.
+ */
+export type PrHandler = (event: PrEvent) => void | Promise<void>;

--- a/craig/src/state/defaults.ts
+++ b/craig/src/state/defaults.ts
@@ -43,5 +43,6 @@ export function createDefaultState(): CraigState {
         info: 0,
       },
     },
+    last_reviewed_prs: {},
   };
 }

--- a/craig/src/state/types.ts
+++ b/craig/src/state/types.ts
@@ -90,4 +90,6 @@ export interface CraigState {
   readonly findings: Finding[];
   /** Aggregated statistics for the current day. */
   readonly daily_stats: DailyStats;
+  /** Map of PR number → last reviewed head SHA. Used by PR watcher. */
+  readonly last_reviewed_prs: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

Implements issue #33: Craig watches for new/updated Pull Requests and auto-reviews them with Security + Code Review Guardians.

## Changes

### New Components

#### `pr-watcher/` — PR Polling Engine
- **PrWatcherPort** — Interface for PR watcher lifecycle and event subscription
- **PrWatcherAdapter** — Polling-based implementation following merge-watcher pattern
- Polls for open PRs at configurable interval (default 120s)
- Compares head SHAs against `last_reviewed_prs` state
- Emits `PrEvent` for new PRs and PRs with new commits
- Respects `pr_monitor` capability toggle — no-op when disabled
- Consecutive failure warnings (threshold: 3)

#### `analyzers/pr-review/` — PR Review Orchestrator
- **PrReviewAnalyzer** — Factory-created analyzer following merge-review pattern
- Invokes Security + Code Review Guardians in parallel on PR diff
- Posts structured PR review comments via `postPRReview()`
- Creates GitHub issues for critical/high findings (with dedup)
- Updates `last_reviewed_prs` state after successful review
- **PrCommentFormatter** — Pure formatting function for PR review comments

### Extended Components

| Component | Change |
|-----------|--------|
| `GitHubPort` | Added `listOpenPRs()`, `getPRDiff()`, `postPRReview()` |
| `GitHubAdapter` | Implemented 3 new methods via Octokit |
| `github.types.ts` | Added `PullRequestInfo`, `CreatePRReviewParams`, `PRReviewReference` |
| `CraigState` | Added `last_reviewed_prs: Record<string, string>` |
| `config.schema.ts` | Added `pr_monitor` capability (default: `false`) |
| `craig.config.yaml` | Enabled `pr_monitor: true`, schedule: `0 */2 * * *` |

## Acceptance Criteria

- ✅ New PR → reviewed with Security + Code Review Guardians
- ✅ PR with new commits → re-reviewed (SHA comparison)
- ✅ PR monitoring disabled → PR polling skipped
- ✅ PR already reviewed at current SHA → skipped

## Tests

- **42 new unit tests** (14 watcher + 17 analyzer + 11 formatter)
- **673 total tests pass** (631 existing + 42 new)
- TypeScript strict mode clean (`noUnusedLocals`, `noUnusedParameters`)

## Architecture Decisions

| # | Decision | Rationale | Reversible? |
|---|----------|-----------|-------------|
| 1 | Default poll interval 120s (vs 60s for merge-watcher) | PRs change less frequently; reduces API rate consumption | Yes |
| 2 | `pr_monitor` defaults to `false` | Opt-in to avoid unexpected API usage for existing users | Yes |
| 3 | Posts reviews as COMMENT (not APPROVE/REQUEST_CHANGES) | Craig should inform, not block — human approval workflow preserved | Yes |
| 4 | Reused merge-review's dual-guardian pattern verbatim | Consistency, proven pattern, DRY | No (but already established) |

Closes #33