### PR TITLE
feat(craig): multi-repo support — monitor multiple repositories

### DIFF
--- a/craig/src/config/__tests__/config.multi-repo.test.ts
+++ b/craig/src/config/__tests__/config.multi-repo.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for multi-repo config schema validation.
+ *
+ * Tests written FIRST per TDD — these define the expected behavior
+ * for the repos array field added in issue #34.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ConfigLoader } from "../config.loader.js";
+import { ConfigValidationError } from "../config.errors.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+async function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "craig-multi-repo-test-"));
+}
+
+async function writeConfig(dir: string, content: string): Promise<string> {
+  const filePath = path.join(dir, "craig.config.yaml");
+  await fs.writeFile(filePath, content, "utf-8");
+  return filePath;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                           */
+/* ------------------------------------------------------------------ */
+
+const MULTI_REPO_YAML = `
+repos:
+  - repo: owner/repo-a
+    branch: main
+    capabilities:
+      merge_review: true
+      security: true
+  - repo: owner/repo-b
+    branch: develop
+    schedule:
+      coverage_scan: "0 10 * * *"
+`;
+
+const SINGLE_REPO_YAML = `
+repo: owner/repo-name
+branch: main
+`;
+
+const MIXED_YAML = `
+repo: owner/default-repo
+repos:
+  - repo: owner/repo-a
+  - repo: owner/repo-b
+`;
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("Config multi-repo support (#34)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── AC4: Backward compatibility — single repo config unchanged ──
+
+  describe("backward compatibility", () => {
+    it("should accept single-repo config with repo field", async () => {
+      const configPath = await writeConfig(tmpDir, SINGLE_REPO_YAML);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repo).toBe("owner/repo-name");
+      expect(config.branch).toBe("main");
+      expect(config.repos).toBeUndefined();
+    });
+
+    it("should apply all defaults for single-repo config", async () => {
+      const configPath = await writeConfig(tmpDir, SINGLE_REPO_YAML);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.capabilities.merge_review).toBe(true);
+      expect(config.autonomy.auto_merge).toBe(false);
+      expect(config.models.default).toBe("claude-sonnet-4.5");
+    });
+  });
+
+  // ─── AC1: Given multiple repos configured, config is valid ────────
+
+  describe("multi-repo config", () => {
+    it("should accept repos array with valid entries", async () => {
+      const configPath = await writeConfig(tmpDir, MULTI_REPO_YAML);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repos).toBeDefined();
+      expect(config.repos).toHaveLength(2);
+      expect(config.repos![0]!.repo).toBe("owner/repo-a");
+      expect(config.repos![1]!.repo).toBe("owner/repo-b");
+    });
+
+    it("should apply default branch to repos entries without branch", async () => {
+      const yaml = `
+repos:
+  - repo: owner/repo-a
+  - repo: owner/repo-b
+    branch: develop
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repos![0]!.branch).toBe("main");
+      expect(config.repos![1]!.branch).toBe("develop");
+    });
+
+    it("should allow per-repo schedule overrides", async () => {
+      const configPath = await writeConfig(tmpDir, MULTI_REPO_YAML);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repos![1]!.schedule).toEqual({
+        coverage_scan: "0 10 * * *",
+      });
+    });
+
+    it("should allow per-repo capabilities", async () => {
+      const yaml = `
+repos:
+  - repo: owner/repo-a
+    capabilities:
+      merge_review: false
+      auto_fix: false
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repos![0]!.capabilities!.merge_review).toBe(false);
+      expect(config.repos![0]!.capabilities!.auto_fix).toBe(false);
+    });
+  });
+
+  // ─── When both repo and repos present, repos takes precedence ────
+
+  describe("repo + repos coexistence", () => {
+    it("should accept config with both repo and repos", async () => {
+      const configPath = await writeConfig(tmpDir, MIXED_YAML);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+      const config = await loader.load(configPath);
+
+      expect(config.repo).toBe("owner/default-repo");
+      expect(config.repos).toHaveLength(2);
+    });
+  });
+
+  // ─── Validation: at least one of repo or repos must be present ────
+
+  describe("validation", () => {
+    it("should reject config with neither repo nor repos", async () => {
+      const yaml = `
+branch: main
+schedule: {}
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow(
+        ConfigValidationError,
+      );
+    });
+
+    it("should reject repos entry without repo field", async () => {
+      const yaml = `
+repos:
+  - branch: main
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow(
+        ConfigValidationError,
+      );
+    });
+
+    it("should reject repos entry with invalid repo format", async () => {
+      const yaml = `
+repos:
+  - repo: invalid-format
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow(
+        ConfigValidationError,
+      );
+    });
+
+    it("should reject repos with empty array", async () => {
+      const yaml = `
+repos: []
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow(
+        ConfigValidationError,
+      );
+    });
+
+    it("should reject repos entry with secret in repo field", async () => {
+      const yaml = `
+repos:
+  - repo: ghp_secrettoken123/repo
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow();
+    });
+
+    it("should reject repos entry with invalid cron in schedule", async () => {
+      const yaml = `
+repos:
+  - repo: owner/repo-a
+    schedule:
+      coverage_scan: "not-a-cron"
+`;
+      const configPath = await writeConfig(tmpDir, yaml);
+      const loader = new ConfigLoader({ baseDir: tmpDir });
+
+      await expect(loader.load(configPath)).rejects.toThrow(
+        ConfigValidationError,
+      );
+    });
+  });
+});

--- a/craig/src/config/config.loader.ts
+++ b/craig/src/config/config.loader.ts
@@ -140,8 +140,8 @@ export class ConfigLoader implements ConfigPort {
   validate(raw: unknown): CraigConfig {
     if (raw === null || raw === undefined) {
       throw new ConfigValidationError(
-        "Config data is empty. At minimum, 'repo' is required.",
-        ["repo is required"],
+        "Config data is empty. At minimum, 'repo' or 'repos' is required.",
+        ["At least one of 'repo' or 'repos' is required"],
       );
     }
 

--- a/craig/src/config/config.schema.ts
+++ b/craig/src/config/config.schema.ts
@@ -76,6 +76,55 @@ const CRON_OR_ON_PUSH = z.string().refine(
 );
 
 /* ------------------------------------------------------------------ */
+/*  Per-repo config (used in repos[] array)                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Schema for a single entry in the repos[] array.
+ * Each entry can override branch, schedule, and capabilities
+ * for that specific repository.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+export const repoEntrySchema = z.object({
+  repo: z
+    .string()
+    .min(1, "repo is required")
+    .regex(REPO_PATTERN, 'repo must be in "owner/repo" format')
+    .refine(isNotSecret, {
+      message: "repo must not contain secrets",
+    }),
+
+  branch: safeString.default("main"),
+
+  schedule: z.record(z.string(), CRON_OR_ON_PUSH).optional(),
+
+  capabilities: z
+    .object({
+      merge_review: z.boolean().optional(),
+      coverage_gaps: z.boolean().optional(),
+      bug_detection: z.boolean().optional(),
+      pattern_enforcement: z.boolean().optional(),
+      po_audit: z.boolean().optional(),
+      auto_fix: z.boolean().optional(),
+      dependency_updates: z.boolean().optional(),
+      pr_monitor: z.boolean().optional(),
+    })
+    .optional(),
+
+  models: z
+    .object({
+      code_review: z.array(safeString).optional(),
+      security: safeString.optional(),
+      default: safeString.optional(),
+    })
+    .optional(),
+});
+
+/** Type for a single repo entry in the repos[] array. */
+export type RepoEntry = z.infer<typeof repoEntrySchema>;
+
+/* ------------------------------------------------------------------ */
 /*  Schema                                                             */
 /* ------------------------------------------------------------------ */
 
@@ -87,7 +136,13 @@ export const craigConfigSchema = z
       .regex(REPO_PATTERN, 'repo must be in "owner/repo" format')
       .refine(isNotSecret, {
         message: "repo must not contain secrets",
-      }),
+      })
+      .optional(),
+
+    repos: z
+      .array(repoEntrySchema)
+      .min(1, "repos array must contain at least one entry")
+      .optional(),
 
     branch: safeString.default("main"),
 
@@ -146,6 +201,16 @@ export const craigConfigSchema = z
   })
   .strip() // Drop unknown fields — prevents secret smuggling via unvalidated keys
   .superRefine((data, ctx) => {
+    // At least one of repo or repos must be present [AC4/AC1]
+    if (!data.repo && (!data.repos || data.repos.length === 0)) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "At least one of 'repo' or 'repos' must be configured.",
+        path: ["repo"],
+      });
+    }
+
     // Recursive secret scan catches secrets in any remaining field,
     // including those in nested records like `schedule`.
     const secretPaths = findSecrets(data);

--- a/craig/src/config/index.ts
+++ b/craig/src/config/index.ts
@@ -10,6 +10,8 @@
 export { ConfigLoader } from "./config.loader.js";
 export type { ConfigPort } from "./config.port.js";
 export type { CraigConfig } from "./config.schema.js";
+export { repoEntrySchema } from "./config.schema.js";
+export type { RepoEntry } from "./config.schema.js";
 export {
   ConfigNotFoundError,
   ConfigValidationError,

--- a/craig/src/core/core.types.ts
+++ b/craig/src/core/core.types.ts
@@ -91,12 +91,14 @@ export interface ToolError {
 /** Input parameters for craig_run_task. */
 export interface RunTaskParams {
   readonly task: string;
+  readonly repo?: string;
 }
 
 /** Input parameters for craig_findings. */
 export interface FindingsParams {
   readonly severity?: string;
   readonly since?: string;
+  readonly repo?: string;
 }
 
 /** Input parameters for craig_schedule. */
@@ -116,4 +118,10 @@ export interface ConfigParams {
 /** Input parameters for craig_digest. */
 export interface DigestParams {
   readonly period?: string;
+  readonly repo?: string;
+}
+
+/** Input parameters for craig_status. */
+export interface StatusParams {
+  readonly repo?: string;
 }

--- a/craig/src/core/index.ts
+++ b/craig/src/core/index.ts
@@ -30,6 +30,7 @@ export type {
   ScheduleParams,
   ConfigParams,
   DigestParams,
+  StatusParams,
   ValidTask,
 } from "./core.types.js";
 export { VALID_TASKS, isValidTask } from "./core.types.js";

--- a/craig/src/core/mcp-server.ts
+++ b/craig/src/core/mcp-server.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import type { StatePort } from "../state/index.js";
 import type { ConfigPort } from "../config/index.js";
 import type { CopilotPort } from "../copilot/index.js";
+import type { RepoManagerPort } from "../repo-manager/index.js";
 import { VALID_TASKS } from "./core.types.js";
 import {
   createStatusHandler,
@@ -36,11 +37,15 @@ import {
  *
  * [SOLID/DIP] Depends on port interfaces, not concrete implementations.
  * All components are injected — the server has no knowledge of adapters.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ *   Added optional repoManager for multi-repo support.
  */
 export interface CraigServerDeps {
   readonly state: StatePort;
   readonly config: ConfigPort;
   readonly copilot: CopilotPort;
+  readonly repoManager?: RepoManagerPort;
 }
 
 /* ------------------------------------------------------------------ */
@@ -111,16 +116,19 @@ function wrapToolResult(
 
 /**
  * Register craig_status — returns current health, running tasks, last runs.
- * No parameters required.
+ * Accepts optional repo parameter for multi-repo mode.
  */
 function registerStatusTool(server: McpServer, deps: CraigServerDeps): void {
-  const handler = createStatusHandler(deps.state);
+  const handler = createStatusHandler(deps.state, deps.repoManager);
 
   server.tool(
     "craig_status",
     "Current state: running tasks, last run times, health",
-    async () => {
-      const result = await handler();
+    {
+      repo: z.string().optional(),
+    },
+    async (args) => {
+      const result = await handler(args);
       return wrapToolResult(result);
     },
   );
@@ -129,15 +137,22 @@ function registerStatusTool(server: McpServer, deps: CraigServerDeps): void {
 /**
  * Register craig_run_task — triggers a specific analyzer task on demand.
  * Validates task name and checks for duplicate runs.
+ * Accepts optional repo parameter for multi-repo mode.
  */
 function registerRunTaskTool(server: McpServer, deps: CraigServerDeps): void {
-  const handler = createRunTaskHandler(deps.state, deps.copilot);
+  const handler = createRunTaskHandler(
+    deps.state,
+    deps.copilot,
+    undefined,
+    deps.repoManager,
+  );
 
   server.tool(
     "craig_run_task",
     "Trigger a specific task on demand",
     {
       task: z.enum(VALID_TASKS),
+      repo: z.string().optional(),
     },
     async (args) => {
       const result = await handler(args);
@@ -148,10 +163,11 @@ function registerRunTaskTool(server: McpServer, deps: CraigServerDeps): void {
 }
 
 /**
- * Register craig_findings — get recent findings filtered by severity or date.
+ * Register craig_findings — get recent findings filtered by severity, date, or repo.
+ * Accepts optional repo parameter: specific repo, "all" for cross-repo, or omit for default.
  */
 function registerFindingsTool(server: McpServer, deps: CraigServerDeps): void {
-  const handler = createFindingsHandler(deps.state);
+  const handler = createFindingsHandler(deps.state, deps.repoManager);
 
   server.tool(
     "craig_findings",
@@ -161,6 +177,7 @@ function registerFindingsTool(server: McpServer, deps: CraigServerDeps): void {
         .enum(["critical", "high", "medium", "low"])
         .optional(),
       since: z.string().optional(),
+      repo: z.string().optional(),
     },
     async (args) => {
       const result = await handler(args);
@@ -215,15 +232,17 @@ function registerConfigTool(server: McpServer, deps: CraigServerDeps): void {
 
 /**
  * Register craig_digest — get the daily/weekly digest summary.
+ * In multi-repo mode, aggregates across all repos or filters by specific repo.
  */
 function registerDigestTool(server: McpServer, deps: CraigServerDeps): void {
-  const handler = createDigestHandler(deps.state);
+  const handler = createDigestHandler(deps.state, deps.repoManager);
 
   server.tool(
     "craig_digest",
     "Get the daily/weekly digest summary",
     {
       period: z.enum(["today", "week", "month"]).optional(),
+      repo: z.string().optional(),
     },
     async (args) => {
       const result = await handler(args);

--- a/craig/src/core/tool-handlers.ts
+++ b/craig/src/core/tool-handlers.ts
@@ -20,6 +20,7 @@ import type { ConfigPort } from "../config/index.js";
 import type { CopilotPort } from "../copilot/index.js";
 import type { AnalyzerContext } from "../analyzers/index.js";
 import type { AnalyzerRegistry } from "./analyzer-registry.js";
+import type { RepoManagerPort } from "../repo-manager/index.js";
 import type {
   StatusResult,
   RunTaskSuccess,
@@ -33,6 +34,7 @@ import type {
   ScheduleParams,
   ConfigParams,
   DigestParams,
+  StatusParams,
 } from "./core.types.js";
 import { isValidTask } from "./core.types.js";
 import { sanitizeError } from "./error-sanitizer.js";
@@ -45,18 +47,20 @@ import { sanitizeError } from "./error-sanitizer.js";
  * Create the handler for the craig_status tool.
  *
  * Delegates to State component to read running_tasks and last_runs.
- * Returns health "ok" always (degraded is reserved for future use
- * when background services are implemented).
+ * When a RepoManager is provided, routes to the correct repo's state.
  *
  * [HEXAGONAL] Adapter layer — reads from StatePort, formats for MCP.
+ * [AC3] Optional repo param routes to specific repo state.
  */
 export function createStatusHandler(
   state: StatePort,
-): () => Promise<StatusResult | ToolError> {
-  return async () => {
+  repoManager?: RepoManagerPort,
+): (params?: StatusParams) => Promise<StatusResult | ToolError> {
+  return async (params) => {
     try {
-      const runningTasks = state.get("running_tasks");
-      const lastRuns = state.get("last_runs");
+      const targetState = resolveState(state, repoManager, params?.repo);
+      const runningTasks = targetState.get("running_tasks");
+      const lastRuns = targetState.get("last_runs");
 
       return {
         running_tasks: runningTasks,
@@ -78,7 +82,7 @@ export function createStatusHandler(
  *
  * Validates the task name, checks for duplicate runs, registers
  * the task in state, and starts the analyzer asynchronously.
- * Returns immediately with a task_id.
+ * When a RepoManager is provided, routes to the correct repo's state.
  *
  * [HEXAGONAL] Adapter layer — validates, delegates to StatePort + AnalyzerRegistry.
  * [CLEAN-CODE] Fail-fast validation, then happy path.
@@ -88,6 +92,7 @@ export function createRunTaskHandler(
   state: StatePort,
   copilot: CopilotPort,
   registry?: AnalyzerRegistry,
+  repoManager?: RepoManagerPort,
 ): (params: RunTaskParams) => Promise<RunTaskSuccess | ToolError> {
   return async (params) => {
     try {
@@ -99,8 +104,11 @@ export function createRunTaskHandler(
         };
       }
 
+      // Resolve state for the target repo
+      const targetState = resolveState(state, repoManager, params.repo);
+
       // Check if already running [Edge case]
-      const runningTasks = state.get("running_tasks");
+      const runningTasks = targetState.get("running_tasks");
       if (runningTasks.includes(params.task)) {
         return {
           error: `Task already running: ${params.task}`,
@@ -112,12 +120,11 @@ export function createRunTaskHandler(
       const taskId = generateTaskId();
 
       // Register as running
-      state.set("running_tasks", [...runningTasks, params.task]);
-      await state.save();
+      targetState.set("running_tasks", [...runningTasks, params.task]);
+      await targetState.save();
 
       // Start analyzer asynchronously (fire-and-forget)
-      // The task will update state when complete.
-      startTaskAsync(params.task, taskId, state, copilot, registry);
+      startTaskAsync(params.task, taskId, targetState, copilot, registry);
 
       return {
         task_id: taskId,
@@ -137,12 +144,14 @@ export function createRunTaskHandler(
  * Create the handler for the craig_findings tool.
  *
  * Delegates filtering entirely to StatePort.getFindings().
- * The state component owns the filter logic.
+ * When repo="all" and RepoManager is present, aggregates across all repos.
  *
  * [HEXAGONAL] Thin adapter — maps MCP params to FindingFilter, returns findings.
+ * [AC3] When repo param provided, filter by repo.
  */
 export function createFindingsHandler(
   state: StatePort,
+  repoManager?: RepoManagerPort,
 ): (params: FindingsParams) => Promise<FindingsResult | ToolError> {
   return async (params) => {
     try {
@@ -153,7 +162,15 @@ export function createFindingsHandler(
         ...(params.since ? { since: params.since } : {}),
       };
 
-      const findings = state.getFindings(filter);
+      // Aggregate across all repos when "all" is specified
+      if (params.repo === "all" && repoManager) {
+        const findings = repoManager.getAllFindings(filter);
+        return { findings };
+      }
+
+      // Route to specific repo or default
+      const targetState = resolveState(state, repoManager, params.repo);
+      const findings = targetState.getFindings(filter);
 
       return { findings };
     } catch (error: unknown) {
@@ -263,20 +280,36 @@ export function createConfigHandler(
 /**
  * Create the handler for the craig_digest tool.
  *
- * Returns daily stats from State. The period parameter is passed
- * through but currently only "today" stats are available (daily_stats).
- * Week/month aggregation is deferred to a future Digest Reporter component.
+ * Returns daily stats from State. In multi-repo mode, aggregates
+ * across all repos when no specific repo is requested.
+ * When a specific repo is provided, returns that repo's stats only.
  *
- * [HEXAGONAL] Adapter layer — reads from StatePort.
- * [YAGNI] Returns what's available now; aggregation comes with Digest Reporter.
+ * [HEXAGONAL] Adapter layer — reads from StatePort or RepoManager.
+ * [AC6] Digest aggregates across all repos.
  */
 export function createDigestHandler(
   state: StatePort,
+  repoManager?: RepoManagerPort,
 ): (params: DigestParams) => Promise<DigestResult | ToolError> {
   return async (params) => {
     try {
-      const dailyStats = state.get("daily_stats");
       const period = params.period ?? "today";
+
+      // Multi-repo aggregation: when repo manager exists and no specific repo
+      if (repoManager && !params.repo) {
+        const aggregated = repoManager.getAggregatedDailyStats();
+        return {
+          merges_reviewed: aggregated.merges_reviewed,
+          issues_created: aggregated.issues_created,
+          prs_opened: aggregated.prs_opened,
+          findings_by_severity: aggregated.findings_by_severity,
+          period,
+        };
+      }
+
+      // Specific repo or single-repo mode
+      const targetState = resolveState(state, repoManager, params.repo);
+      const dailyStats = targetState.get("daily_stats");
 
       return {
         merges_reviewed: dailyStats.merges_reviewed,
@@ -294,6 +327,28 @@ export function createDigestHandler(
 /* ------------------------------------------------------------------ */
 /*  Private Helpers                                                    */
 /* ------------------------------------------------------------------ */
+
+/**
+ * Resolve the target StatePort for a tool handler.
+ *
+ * When a RepoManager is available and a repo is specified (or defaulted),
+ * returns the state for that specific repo. Otherwise falls back to
+ * the injected state (single-repo backward compatibility).
+ *
+ * [AC4] Backward compatible — works without RepoManager.
+ * [AC3] Routes to specific repo when provided.
+ */
+function resolveState(
+  fallbackState: StatePort,
+  repoManager?: RepoManagerPort,
+  repo?: string,
+): StatePort {
+  if (!repoManager) {
+    return fallbackState;
+  }
+  const resolved = repoManager.resolveRepo(repo);
+  return repoManager.getState(resolved);
+}
 
 /**
  * Create a standard tool error response.

--- a/craig/src/index.ts
+++ b/craig/src/index.ts
@@ -24,6 +24,8 @@ import { CopilotAdapter } from "./copilot/index.js";
 import { createCraigServer } from "./core/index.js";
 import { parseCliArgs } from "./cli/index.js";
 import { startDaemonServer } from "./daemon/index.js";
+import { RepoManager } from "./repo-manager/index.js";
+import type { StateFactory } from "./repo-manager/index.js";
 
 /**
  * Bootstrap and start the Craig MCP server.
@@ -50,20 +52,31 @@ async function main(): Promise<void> {
     const cfg = config.get();
 
     // [SECURITY] Log to stderr — stdout is for MCP JSON-RPC in stdio mode
-    console.error(`[Craig] Starting for repo: ${cfg.repo}`);
+    const repoNames = cfg.repos
+      ? cfg.repos.map((r) => r.repo).join(", ")
+      : cfg.repo ?? "unknown";
+    console.error(`[Craig] Starting for repo(s): ${repoNames}`);
 
-    // 3. Initialize state
-    const state = new FileStateAdapter(".craig-state.json");
-    await state.load();
+    // 3. Initialize multi-repo manager
+    //    In single-repo mode (no repos[]), creates one state with default path.
+    //    In multi-repo mode, creates separate state files per repo.
+    const stateFactory: StateFactory = (filePath: string) =>
+      new FileStateAdapter(filePath);
+    const repoManager = new RepoManager(cfg, stateFactory);
+    await repoManager.initialize();
 
-    // 4. Create Copilot adapter
+    // 4. Default state for backward-compatible handler fallback
+    const defaultRepo = repoManager.getDefaultRepo();
+    const state = repoManager.getState(defaultRepo);
+
+    // 5. Create Copilot adapter
     const copilot = new CopilotAdapter({
       defaultModel: cfg.models.default,
       guardiansPath: cfg.guardians.path,
     });
 
-    // 5. Create and configure MCP server
-    const server = createCraigServer({ state, config, copilot });
+    // 6. Create and configure MCP server
+    const server = createCraigServer({ state, config, copilot, repoManager });
 
     if (args.daemon) {
       // 6b. Daemon mode: SSE transport over HTTP

--- a/craig/src/repo-manager/__tests__/multi-repo-tools.test.ts
+++ b/craig/src/repo-manager/__tests__/multi-repo-tools.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for multi-repo MCP tool handler support.
+ *
+ * Tests written FIRST per TDD — verify that MCP tool handlers
+ * accept an optional `repo` parameter and route to the correct
+ * repo instance via RepoManager.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createStatusHandler,
+  createFindingsHandler,
+  createDigestHandler,
+  createRunTaskHandler,
+} from "../../core/tool-handlers.js";
+import type { StatePort } from "../../state/index.js";
+import type { CopilotPort } from "../../copilot/index.js";
+import type { RepoManagerPort } from "../repo-manager.port.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function createMockState(): StatePort {
+  return {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+    addFinding: vi.fn(),
+    getFindings: vi.fn().mockReturnValue([]),
+  };
+}
+
+function createMockCopilot(): CopilotPort {
+  return {
+    invoke: vi.fn().mockResolvedValue({
+      success: true,
+      output: "Review complete",
+      duration_ms: 1500,
+      model_used: "claude-sonnet-4.5",
+    }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createMockRepoManager(repos: string[]): RepoManagerPort {
+  const states = new Map<string, StatePort>();
+  for (const repo of repos) {
+    states.set(repo, createMockState());
+  }
+
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getRepos: vi.fn().mockReturnValue(repos),
+    getDefaultRepo: vi.fn().mockReturnValue(repos[0]),
+    getState: vi.fn().mockImplementation((repo: string) => {
+      const state = states.get(repo);
+      if (!state) throw new Error(`Unknown repository: ${repo}`);
+      return state;
+    }),
+    getRepoConfig: vi.fn().mockReturnValue({
+      repo: repos[0],
+      branch: "main",
+    }),
+    resolveRepo: vi.fn().mockImplementation((repo?: string) => {
+      if (!repo) return repos[0]!;
+      if (!repos.includes(repo)) throw new Error(`Unknown repository: ${repo}`);
+      return repo;
+    }),
+    getAllFindings: vi.fn().mockReturnValue([]),
+    getAggregatedDailyStats: vi.fn().mockReturnValue({
+      merges_reviewed: 0,
+      issues_created: 0,
+      prs_opened: 0,
+      findings_by_severity: { critical: 0, high: 0, medium: 0, low: 0, info: 0 },
+    }),
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("MCP tools with repo parameter (#34)", () => {
+
+  // ─── AC3: craig_findings with repo param ──────────────────────────
+
+  describe("craig_findings with repo parameter", () => {
+    it("should filter by specific repo when repo param provided", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const handler = createFindingsHandler(
+        createMockState(), // default state (backward compat)
+        repoManager,
+      );
+
+      await handler({ severity: "high", repo: "owner/repo-b" });
+
+      expect(repoManager.resolveRepo).toHaveBeenCalledWith("owner/repo-b");
+      const stateB = repoManager.getState("owner/repo-b");
+      expect(stateB.getFindings).toHaveBeenCalled();
+    });
+
+    it("should use default repo when repo param omitted", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const handler = createFindingsHandler(
+        createMockState(),
+        repoManager,
+      );
+
+      await handler({ severity: "high" });
+
+      expect(repoManager.resolveRepo).toHaveBeenCalledWith(undefined);
+    });
+
+    it("should return all repos findings when repo param is 'all'", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const findingsA = [
+        { id: "1", severity: "high" as const, category: "security", issue: "XSS", source: "s-g", detected_at: "2024-01-01", task: "security_scan", repo: "owner/repo-a" },
+      ];
+      vi.mocked(repoManager.getAllFindings).mockReturnValue(findingsA);
+
+      const handler = createFindingsHandler(
+        createMockState(),
+        repoManager,
+      );
+
+      const result = await handler({ repo: "all" });
+      expect(repoManager.getAllFindings).toHaveBeenCalled();
+      expect("findings" in result).toBe(true);
+    });
+
+    it("should work without RepoManager (single-repo backward compat)", async () => {
+      const state = createMockState();
+      vi.mocked(state.getFindings).mockReturnValue([]);
+
+      const handler = createFindingsHandler(state);
+      const result = await handler({ severity: "high" });
+
+      expect("findings" in result).toBe(true);
+      expect(state.getFindings).toHaveBeenCalled();
+    });
+  });
+
+  // ─── craig_status with repo parameter ─────────────────────────────
+
+  describe("craig_status with repo parameter", () => {
+    it("should return status for specific repo", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const stateA = repoManager.getState("owner/repo-a");
+      vi.mocked(stateA.get).mockImplementation((key: string) => {
+        if (key === "running_tasks") return ["security_scan"];
+        if (key === "last_runs") return { security_scan: "2024-01-01T00:00:00Z" };
+        return [] as never;
+      });
+
+      const handler = createStatusHandler(
+        createMockState(),
+        repoManager,
+      );
+
+      const result = await handler({ repo: "owner/repo-a" });
+
+      expect("running_tasks" in result).toBe(true);
+      if ("running_tasks" in result) {
+        expect(result.running_tasks).toEqual(["security_scan"]);
+      }
+    });
+
+    it("should work without RepoManager (backward compat)", async () => {
+      const state = createMockState();
+      vi.mocked(state.get).mockImplementation((key: string) => {
+        if (key === "running_tasks") return [];
+        if (key === "last_runs") return {};
+        return [] as never;
+      });
+
+      const handler = createStatusHandler(state);
+      const result = await handler();
+
+      expect("health" in result).toBe(true);
+    });
+  });
+
+  // ─── craig_digest with repo aggregation ───────────────────────────
+
+  describe("craig_digest with repo parameter", () => {
+    it("should aggregate across repos when no repo specified", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      vi.mocked(repoManager.getAggregatedDailyStats).mockReturnValue({
+        merges_reviewed: 10,
+        issues_created: 5,
+        prs_opened: 3,
+        findings_by_severity: { critical: 1, high: 2, medium: 3, low: 4, info: 0 },
+      });
+
+      const handler = createDigestHandler(
+        createMockState(),
+        repoManager,
+      );
+
+      const result = await handler({});
+      expect("merges_reviewed" in result).toBe(true);
+      if ("merges_reviewed" in result) {
+        expect(result.merges_reviewed).toBe(10);
+      }
+    });
+
+    it("should return single-repo digest when repo specified", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const stateA = repoManager.getState("owner/repo-a");
+      vi.mocked(stateA.get).mockImplementation((key: string) => {
+        if (key === "daily_stats") {
+          return {
+            merges_reviewed: 7,
+            issues_created: 2,
+            prs_opened: 1,
+            findings_by_severity: { critical: 0, high: 1, medium: 0, low: 0, info: 0 },
+          };
+        }
+        return [] as never;
+      });
+
+      const handler = createDigestHandler(
+        createMockState(),
+        repoManager,
+      );
+
+      const result = await handler({ repo: "owner/repo-a" });
+      expect("merges_reviewed" in result).toBe(true);
+      if ("merges_reviewed" in result) {
+        expect(result.merges_reviewed).toBe(7);
+      }
+    });
+  });
+
+  // ─── craig_run_task with repo parameter ───────────────────────────
+
+  describe("craig_run_task with repo parameter", () => {
+    it("should run task on specified repo state", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a", "owner/repo-b"]);
+      const stateA = repoManager.getState("owner/repo-a");
+      vi.mocked(stateA.get).mockReturnValue([]);
+
+      const handler = createRunTaskHandler(
+        createMockState(),
+        createMockCopilot(),
+        undefined,
+        repoManager,
+      );
+
+      const result = await handler({ task: "security_scan", repo: "owner/repo-a" });
+      expect("task_id" in result).toBe(true);
+    });
+
+    it("should use default repo state when no repo specified", async () => {
+      const repoManager = createMockRepoManager(["owner/repo-a"]);
+      const stateA = repoManager.getState("owner/repo-a");
+      vi.mocked(stateA.get).mockReturnValue([]);
+
+      const handler = createRunTaskHandler(
+        createMockState(),
+        createMockCopilot(),
+        undefined,
+        repoManager,
+      );
+
+      const result = await handler({ task: "security_scan" });
+      expect("task_id" in result).toBe(true);
+    });
+  });
+});

--- a/craig/src/repo-manager/__tests__/repo-manager.adapter.test.ts
+++ b/craig/src/repo-manager/__tests__/repo-manager.adapter.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for RepoManager — multi-repo orchestration component.
+ *
+ * Tests written FIRST per TDD — these define the expected behavior
+ * for the RepoManager port that coordinates per-repo state,
+ * watchers, and schedulers.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { StatePort } from "../../state/index.js";
+import type { CraigConfig } from "../../config/index.js";
+import { RepoManager } from "../repo-manager.adapter.js";
+import type { RepoManagerPort, RepoInstance } from "../repo-manager.port.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function createMockState(repoName?: string): StatePort {
+  return {
+    load: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockReturnValue([]),
+    set: vi.fn(),
+    addFinding: vi.fn(),
+    getFindings: vi.fn().mockReturnValue([]),
+  };
+}
+
+/** Factory for creating StatePort instances — injectable for testing. */
+type StateFactory = (filePath: string) => StatePort;
+
+function createMockStateFactory(): {
+  factory: StateFactory;
+  instances: Map<string, StatePort>;
+} {
+  const instances = new Map<string, StatePort>();
+  const factory: StateFactory = (filePath: string) => {
+    const state = createMockState();
+    instances.set(filePath, state);
+    return state;
+  };
+  return { factory, instances };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                           */
+/* ------------------------------------------------------------------ */
+
+const SINGLE_REPO_CONFIG: CraigConfig = {
+  repo: "owner/repo-name",
+  branch: "main",
+  schedule: { coverage_scan: "0 8 * * *" },
+  capabilities: {
+    merge_review: true,
+    coverage_gaps: true,
+    bug_detection: true,
+    pattern_enforcement: true,
+    po_audit: true,
+    auto_fix: true,
+    dependency_updates: true,
+    pr_monitor: false,
+  },
+  models: { default: "claude-sonnet-4.5" },
+  autonomy: { create_issues: true, create_draft_prs: true, auto_merge: false as const },
+  guardians: { path: "~/.copilot/" },
+};
+
+const MULTI_REPO_CONFIG: CraigConfig = {
+  ...SINGLE_REPO_CONFIG,
+  repo: "owner/repo-name",
+  repos: [
+    {
+      repo: "owner/repo-a",
+      branch: "main",
+      schedule: { merge_monitor: "on_push" },
+    },
+    {
+      repo: "owner/repo-b",
+      branch: "develop",
+      schedule: { coverage_scan: "0 10 * * *" },
+      capabilities: { merge_review: false },
+    },
+  ],
+};
+
+const REPOS_ONLY_CONFIG: CraigConfig = {
+  ...SINGLE_REPO_CONFIG,
+  repo: undefined as unknown as string,
+  repos: [
+    { repo: "org/service-a", branch: "main" },
+    { repo: "org/service-b", branch: "main" },
+    { repo: "org/service-c", branch: "release" },
+  ],
+};
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("RepoManager (#34)", () => {
+  let manager: RepoManagerPort;
+  let stateFactory: ReturnType<typeof createMockStateFactory>;
+
+  // ─── AC4: Single-repo backward compatibility ─────────────────────
+
+  describe("single-repo mode (backward compatible)", () => {
+    beforeEach(async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(SINGLE_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+    });
+
+    it("should return exactly one repo", () => {
+      expect(manager.getRepos()).toEqual(["owner/repo-name"]);
+    });
+
+    it("should return the single repo as default", () => {
+      expect(manager.getDefaultRepo()).toBe("owner/repo-name");
+    });
+
+    it("should resolve undefined repo to the default", () => {
+      expect(manager.resolveRepo(undefined)).toBe("owner/repo-name");
+    });
+
+    it("should resolve explicit repo to itself", () => {
+      expect(manager.resolveRepo("owner/repo-name")).toBe("owner/repo-name");
+    });
+
+    it("should create state with standard file path", () => {
+      const state = manager.getState("owner/repo-name");
+      expect(state).toBeDefined();
+      expect(stateFactory.instances.has(".craig-state.json")).toBe(true);
+    });
+
+    it("should load state on initialize", () => {
+      const state = stateFactory.instances.get(".craig-state.json")!;
+      expect(state.load).toHaveBeenCalled();
+    });
+  });
+
+  // ─── AC1: Multi-repo mode ────────────────────────────────────────
+
+  describe("multi-repo mode", () => {
+    beforeEach(async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+    });
+
+    it("should return all configured repos", () => {
+      expect(manager.getRepos()).toEqual(["owner/repo-a", "owner/repo-b"]);
+    });
+
+    it("should return first repo as default", () => {
+      expect(manager.getDefaultRepo()).toBe("owner/repo-a");
+    });
+
+    it("should create separate state files per repo", () => {
+      expect(
+        stateFactory.instances.has(".craig-state-owner-repo-a.json"),
+      ).toBe(true);
+      expect(
+        stateFactory.instances.has(".craig-state-owner-repo-b.json"),
+      ).toBe(true);
+    });
+
+    it("should return correct state for each repo", () => {
+      const stateA = manager.getState("owner/repo-a");
+      const stateB = manager.getState("owner/repo-b");
+
+      expect(stateA).toBeDefined();
+      expect(stateB).toBeDefined();
+      expect(stateA).not.toBe(stateB);
+    });
+
+    it("should load all states on initialize", () => {
+      for (const [, state] of stateFactory.instances) {
+        expect(state.load).toHaveBeenCalled();
+      }
+    });
+
+    it("should resolve undefined repo to default (first)", () => {
+      expect(manager.resolveRepo(undefined)).toBe("owner/repo-a");
+    });
+
+    it("should resolve explicit repo to itself", () => {
+      expect(manager.resolveRepo("owner/repo-b")).toBe("owner/repo-b");
+    });
+  });
+
+  // ─── AC2: Per-repo schedule config ───────────────────────────────
+
+  describe("per-repo config", () => {
+    beforeEach(async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+    });
+
+    it("should return per-repo schedule", () => {
+      const configA = manager.getRepoConfig("owner/repo-a");
+      const configB = manager.getRepoConfig("owner/repo-b");
+
+      expect(configA.schedule).toEqual({ merge_monitor: "on_push" });
+      expect(configB.schedule).toEqual({ coverage_scan: "0 10 * * *" });
+    });
+
+    it("should return per-repo branch", () => {
+      const configA = manager.getRepoConfig("owner/repo-a");
+      const configB = manager.getRepoConfig("owner/repo-b");
+
+      expect(configA.branch).toBe("main");
+      expect(configB.branch).toBe("develop");
+    });
+
+    it("should return per-repo capabilities override", () => {
+      const configB = manager.getRepoConfig("owner/repo-b");
+      expect(configB.capabilities?.merge_review).toBe(false);
+    });
+  });
+
+  // ─── Error handling ──────────────────────────────────────────────
+
+  describe("error handling", () => {
+    beforeEach(async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+    });
+
+    it("should throw for unknown repo in getState", () => {
+      expect(() => manager.getState("unknown/repo")).toThrow(
+        "Unknown repository: unknown/repo",
+      );
+    });
+
+    it("should throw for unknown repo in getRepoConfig", () => {
+      expect(() => manager.getRepoConfig("unknown/repo")).toThrow(
+        "Unknown repository: unknown/repo",
+      );
+    });
+
+    it("should throw for unknown repo in resolveRepo", () => {
+      expect(() => manager.resolveRepo("unknown/repo")).toThrow(
+        "Unknown repository: unknown/repo",
+      );
+    });
+  });
+
+  // ─── State file isolation (security) ─────────────────────────────
+
+  describe("state file isolation", () => {
+    it("should use repo-qualified file paths for multi-repo", async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(REPOS_ONLY_CONFIG, stateFactory.factory);
+      await manager.initialize();
+
+      const paths = [...stateFactory.instances.keys()];
+      expect(paths).toContain(".craig-state-org-service-a.json");
+      expect(paths).toContain(".craig-state-org-service-b.json");
+      expect(paths).toContain(".craig-state-org-service-c.json");
+    });
+
+    it("should not share state between repos", async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+
+      const stateA = manager.getState("owner/repo-a");
+      const stateB = manager.getState("owner/repo-b");
+
+      // They should be different instances
+      expect(stateA).not.toBe(stateB);
+    });
+  });
+
+  // ─── getAllFindings aggregation ───────────────────────────────────
+
+  describe("cross-repo aggregation", () => {
+    it("should aggregate findings across all repos", async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+
+      const stateA = manager.getState("owner/repo-a");
+      const stateB = manager.getState("owner/repo-b");
+
+      const findingsA = [
+        { id: "1", severity: "high" as const, category: "security", issue: "XSS", source: "security-guardian", detected_at: "2024-01-01", task: "security_scan" },
+      ];
+      const findingsB = [
+        { id: "2", severity: "low" as const, category: "style", issue: "naming", source: "code-review-guardian", detected_at: "2024-01-02", task: "pattern_check" },
+      ];
+
+      vi.mocked(stateA.getFindings).mockReturnValue(findingsA);
+      vi.mocked(stateB.getFindings).mockReturnValue(findingsB);
+
+      const all = manager.getAllFindings();
+      expect(all).toHaveLength(2);
+      expect(all).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: "1", repo: "owner/repo-a" }),
+        expect.objectContaining({ id: "2", repo: "owner/repo-b" }),
+      ]));
+    });
+
+    it("should filter aggregated findings by severity", async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+
+      const stateA = manager.getState("owner/repo-a");
+      vi.mocked(stateA.getFindings).mockReturnValue([
+        { id: "1", severity: "high" as const, category: "security", issue: "XSS", source: "s-g", detected_at: "2024-01-01", task: "security_scan" },
+      ]);
+
+      const all = manager.getAllFindings({ severity: "high" });
+      expect(stateA.getFindings).toHaveBeenCalledWith({ severity: "high" });
+    });
+  });
+
+  // ─── getAllDailyStats aggregation ─────────────────────────────────
+
+  describe("digest aggregation", () => {
+    it("should aggregate daily stats across all repos", async () => {
+      stateFactory = createMockStateFactory();
+      manager = new RepoManager(MULTI_REPO_CONFIG, stateFactory.factory);
+      await manager.initialize();
+
+      const stateA = manager.getState("owner/repo-a");
+      const stateB = manager.getState("owner/repo-b");
+
+      vi.mocked(stateA.get).mockImplementation((key: string) => {
+        if (key === "daily_stats") {
+          return {
+            merges_reviewed: 3,
+            issues_created: 2,
+            prs_opened: 1,
+            findings_by_severity: { critical: 1, high: 0, medium: 2, low: 0, info: 0 },
+          };
+        }
+        return [] as never;
+      });
+
+      vi.mocked(stateB.get).mockImplementation((key: string) => {
+        if (key === "daily_stats") {
+          return {
+            merges_reviewed: 5,
+            issues_created: 1,
+            prs_opened: 0,
+            findings_by_severity: { critical: 0, high: 3, medium: 1, low: 0, info: 0 },
+          };
+        }
+        return [] as never;
+      });
+
+      const aggregated = manager.getAggregatedDailyStats();
+      expect(aggregated.merges_reviewed).toBe(8);
+      expect(aggregated.issues_created).toBe(3);
+      expect(aggregated.prs_opened).toBe(1);
+      expect(aggregated.findings_by_severity.critical).toBe(1);
+      expect(aggregated.findings_by_severity.high).toBe(3);
+      expect(aggregated.findings_by_severity.medium).toBe(3);
+    });
+  });
+});

--- a/craig/src/repo-manager/index.ts
+++ b/craig/src/repo-manager/index.ts
@@ -1,0 +1,17 @@
+/**
+ * RepoManager component — public API barrel export.
+ *
+ * All consumers import from here, never from internals.
+ * This is the component boundary.
+ *
+ * @module repo-manager
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+export { RepoManager } from "./repo-manager.adapter.js";
+export type { StateFactory } from "./repo-manager.adapter.js";
+export type {
+  RepoManagerPort,
+  RepoInstance,
+  RepoFinding,
+} from "./repo-manager.port.js";

--- a/craig/src/repo-manager/repo-manager.adapter.ts
+++ b/craig/src/repo-manager/repo-manager.adapter.ts
@@ -1,0 +1,200 @@
+/**
+ * RepoManager — Adapter implementation of RepoManagerPort.
+ *
+ * Orchestrates per-repo state instances for multi-repo monitoring.
+ * In single-repo mode, creates one instance with the default state file path.
+ * In multi-repo mode, creates separate state files per repo.
+ *
+ * [HEXAGONAL] Adapter — implements RepoManagerPort for filesystem-backed state.
+ * [SOLID/SRP] Manages repo lifecycle only — no business logic.
+ * [CLEAN-CODE] Small functions, clear names, immutable where possible.
+ *
+ * @module repo-manager
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+import type { StatePort, FindingFilter, DailyStats } from "../state/index.js";
+import type { CraigConfig, RepoEntry } from "../config/index.js";
+import type { RepoManagerPort, RepoInstance, RepoFinding } from "./repo-manager.port.js";
+
+/** Factory function for creating StatePort instances with a given file path. */
+export type StateFactory = (filePath: string) => StatePort;
+
+/**
+ * Default state file path for single-repo mode (backward compatible).
+ * @see [AC4] — no breaking change for single-repo configs.
+ */
+const DEFAULT_STATE_FILE = ".craig-state.json";
+
+/**
+ * Generate a repo-qualified state file path.
+ * Replaces "/" with "-" to create valid filenames.
+ *
+ * @example stateFilePath("owner/repo") → ".craig-state-owner-repo.json"
+ */
+function stateFilePath(repo: string): string {
+  const sanitized = repo.replace(/\//g, "-");
+  return `.craig-state-${sanitized}.json`;
+}
+
+export class RepoManager implements RepoManagerPort {
+  private readonly instances = new Map<string, RepoInstance>();
+  private readonly repoOrder: string[] = [];
+  private readonly config: CraigConfig;
+  private readonly createState: StateFactory;
+
+  constructor(config: CraigConfig, createState: StateFactory) {
+    this.config = config;
+    this.createState = createState;
+  }
+
+  /**
+   * Initialize all repo instances.
+   *
+   * In multi-repo mode (repos[] present): creates one instance per entry.
+   * In single-repo mode (repo only): creates one instance with default state path.
+   *
+   * [AC1] Multiple repos → monitors all of them.
+   * [AC4] Single repo → backward compatible (no breaking change).
+   */
+  async initialize(): Promise<void> {
+    if (this.config.repos && this.config.repos.length > 0) {
+      await this.initializeMultiRepo(this.config.repos);
+    } else if (this.config.repo) {
+      await this.initializeSingleRepo(this.config.repo);
+    }
+  }
+
+  // ─── Public API ─────────────────────────────────────────────────
+
+  getRepos(): string[] {
+    return [...this.repoOrder];
+  }
+
+  getDefaultRepo(): string {
+    return this.repoOrder[0]!;
+  }
+
+  getState(repo: string): StatePort {
+    const instance = this.instances.get(repo);
+    if (!instance) {
+      throw new Error(`Unknown repository: ${repo}`);
+    }
+    return instance.state;
+  }
+
+  getRepoConfig(repo: string): RepoEntry {
+    const instance = this.instances.get(repo);
+    if (!instance) {
+      throw new Error(`Unknown repository: ${repo}`);
+    }
+    return instance.config;
+  }
+
+  resolveRepo(repo?: string): string {
+    if (!repo) {
+      return this.getDefaultRepo();
+    }
+    if (!this.instances.has(repo)) {
+      throw new Error(`Unknown repository: ${repo}`);
+    }
+    return repo;
+  }
+
+  /**
+   * Aggregate findings across all repos, enriching each with its repo identifier.
+   *
+   * [AC3] When repo param is "all", return findings from all repos.
+   * [SECURITY] State files are repo-isolated — no cross-repo data leakage.
+   */
+  getAllFindings(filter?: FindingFilter): RepoFinding[] {
+    const allFindings: RepoFinding[] = [];
+
+    for (const [repoName, instance] of this.instances) {
+      const findings = instance.state.getFindings(filter);
+      for (const finding of findings) {
+        allFindings.push({ ...finding, repo: repoName });
+      }
+    }
+
+    return allFindings;
+  }
+
+  /**
+   * Aggregate daily stats across all repos by summing each field.
+   *
+   * Uses mutable accumulators internally, returns immutable DailyStats.
+   * Used by craig_digest when no specific repo is requested.
+   */
+  getAggregatedDailyStats(): DailyStats {
+    let mergesReviewed = 0;
+    let issuesCreated = 0;
+    let prsOpened = 0;
+    const severity: Record<string, number> = {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+    };
+
+    for (const [, instance] of this.instances) {
+      const stats = instance.state.get("daily_stats");
+      mergesReviewed += stats.merges_reviewed;
+      issuesCreated += stats.issues_created;
+      prsOpened += stats.prs_opened;
+
+      for (const key of Object.keys(severity)) {
+        severity[key]! += stats.findings_by_severity[key as keyof typeof stats.findings_by_severity] ?? 0;
+      }
+    }
+
+    return {
+      merges_reviewed: mergesReviewed,
+      issues_created: issuesCreated,
+      prs_opened: prsOpened,
+      findings_by_severity: severity as DailyStats["findings_by_severity"],
+    };
+  }
+
+  // ─── Private: Initialization ────────────────────────────────────
+
+  /**
+   * Initialize multi-repo mode: one instance per repos[] entry.
+   * Each gets its own state file: .craig-state-{owner}-{repo}.json
+   */
+  private async initializeMultiRepo(repos: readonly RepoEntry[]): Promise<void> {
+    for (const entry of repos) {
+      const filePath = stateFilePath(entry.repo);
+      const state = this.createState(filePath);
+      await state.load();
+
+      this.instances.set(entry.repo, {
+        repo: entry.repo,
+        config: entry,
+        state,
+      });
+      this.repoOrder.push(entry.repo);
+    }
+  }
+
+  /**
+   * Initialize single-repo mode: one instance with the default state file.
+   * [AC4] Backward compatible — uses ".craig-state.json".
+   */
+  private async initializeSingleRepo(repo: string): Promise<void> {
+    const state = this.createState(DEFAULT_STATE_FILE);
+    await state.load();
+
+    const entry: RepoEntry = {
+      repo,
+      branch: this.config.branch,
+      schedule: this.config.schedule,
+      capabilities: this.config.capabilities,
+      models: this.config.models,
+    };
+
+    this.instances.set(repo, { repo, config: entry, state });
+    this.repoOrder.push(repo);
+  }
+}

--- a/craig/src/repo-manager/repo-manager.port.ts
+++ b/craig/src/repo-manager/repo-manager.port.ts
@@ -1,0 +1,89 @@
+/**
+ * RepoManagerPort — Public interface for multi-repo orchestration.
+ *
+ * All consumers depend on this port, never on the implementation.
+ * The RepoManager coordinates per-repo state instances and provides
+ * cross-repo aggregation for digest and findings queries.
+ *
+ * [HEXAGONAL] Inward-facing port — adapter implements concrete logic.
+ * [SOLID/ISP] Consumers only see what they need: state lookup, config, aggregation.
+ *
+ * @module repo-manager
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/34
+ */
+
+import type { StatePort, FindingFilter, Finding, DailyStats } from "../state/index.js";
+import type { RepoEntry } from "../config/index.js";
+
+/**
+ * A finding enriched with its source repository identifier.
+ * Used when aggregating findings across multiple repositories.
+ */
+export interface RepoFinding extends Finding {
+  /** The "owner/repo" this finding belongs to. */
+  readonly repo: string;
+}
+
+/**
+ * Per-repo instance managed by RepoManager.
+ * Each repo has its own state and config.
+ */
+export interface RepoInstance {
+  /** Repository identifier ("owner/repo"). */
+  readonly repo: string;
+  /** Per-repo config (branch, schedule, capabilities overrides). */
+  readonly config: RepoEntry;
+  /** Per-repo state port instance. */
+  readonly state: StatePort;
+}
+
+/**
+ * Port for multi-repository orchestration.
+ *
+ * Manages per-repo state instances, provides repo routing,
+ * and aggregates data across all monitored repositories.
+ */
+export interface RepoManagerPort {
+  /**
+   * Initialize all repo instances — loads state for each repo.
+   * Must be called before any other method.
+   */
+  initialize(): Promise<void>;
+
+  /** Get list of all configured repo identifiers ("owner/repo"). */
+  getRepos(): string[];
+
+  /** Get the default repo identifier (first in the list). */
+  getDefaultRepo(): string;
+
+  /**
+   * Get the state port for a specific repo.
+   * @throws {Error} If the repo is not configured.
+   */
+  getState(repo: string): StatePort;
+
+  /**
+   * Get the per-repo config for a specific repo.
+   * @throws {Error} If the repo is not configured.
+   */
+  getRepoConfig(repo: string): RepoEntry;
+
+  /**
+   * Resolve an optional repo parameter to a concrete repo identifier.
+   * - If undefined, returns the default repo.
+   * - If a known repo, returns it.
+   * - If unknown, throws an error.
+   */
+  resolveRepo(repo?: string): string;
+
+  /**
+   * Get findings aggregated across all repos, enriched with repo field.
+   * @param filter - Optional filter criteria (severity, since, task).
+   */
+  getAllFindings(filter?: FindingFilter): RepoFinding[];
+
+  /**
+   * Get daily stats aggregated (summed) across all repos.
+   */
+  getAggregatedDailyStats(): DailyStats;
+}


### PR DESCRIPTION
## Summary

Extends Craig to monitor multiple repositories from a single instance.

Closes #34

## Changes

### New: `repo-manager/` component `[HEXAGONAL]`
- `RepoManagerPort` interface for multi-repo orchestration
- `RepoManager` adapter: per-repo state files, config routing, aggregation
- State file isolation: `.craig-state-{owner}-{repo}.json` per repo
- Cross-repo findings aggregation and daily stats summation

### Config schema extension `[DRY]`
- Added `repos[]` array field with per-repo overrides (branch, schedule, capabilities, models)
- Made `repo` field optional when `repos[]` is present
- Backward compatible: single-repo config unchanged
- Validation: at least one of `repo` or `repos` required
- Secret detection applies to repos entries

### MCP tools: optional `repo` parameter `[AC3]`
- `craig_status`, `craig_run_task`, `craig_findings`, `craig_digest` accept optional `repo` param
- `craig_findings` supports `repo='all'` for cross-repo aggregation
- `craig_digest` aggregates across repos when no repo specified
- All tools work without RepoManager (backward compatible)

### Entry point multi-repo bootstrap
- Uses RepoManager for state lifecycle management
- StateFactory pattern for dependency injection

## Config Example

```yaml
# Single repo (backward compatible — no changes needed)
repo: owner/repo

# Multi-repo
repos:
  - repo: owner/repo-a
    branch: main
    capabilities:
      merge_review: true
      security: true
  - repo: owner/repo-b
    branch: develop
    schedule:
      coverage_scan: '0 10 * * *'
```

## Test Coverage
- **47 new tests** (13 config, 24 repo-manager, 10 tool routing)
- **741 total tests passing**, 0 regressions
- TypeScript strict mode: zero errors

## Files Changed (14)
| File | Change |
|------|--------|
| `craig/src/repo-manager/repo-manager.port.ts` | New — RepoManagerPort interface |
| `craig/src/repo-manager/repo-manager.adapter.ts` | New — RepoManager implementation |
| `craig/src/repo-manager/index.ts` | New — barrel export |
| `craig/src/config/config.schema.ts` | Extended — repos[] array, repo optional |
| `craig/src/config/config.loader.ts` | Updated — validation message |
| `craig/src/config/index.ts` | Updated — export RepoEntry type |
| `craig/src/core/core.types.ts` | Extended — repo param on tool types |
| `craig/src/core/tool-handlers.ts` | Extended — repo routing via RepoManager |
| `craig/src/core/mcp-server.ts` | Extended — repo param on MCP schemas |
| `craig/src/core/index.ts` | Updated — export StatusParams |
| `craig/src/index.ts` | Updated — multi-repo bootstrap |
| `craig/src/config/__tests__/config.multi-repo.test.ts` | New — 13 tests |
| `craig/src/repo-manager/__tests__/repo-manager.adapter.test.ts` | New — 24 tests |
| `craig/src/repo-manager/__tests__/multi-repo-tools.test.ts` | New — 10 tests |