### PR TITLE
fix(daemon): graceful shutdown with active SSE connections

### DIFF
--- a/craig/src/daemon/__tests__/daemon-server.test.ts
+++ b/craig/src/daemon/__tests__/daemon-server.test.ts
@@ -248,4 +248,65 @@ describe("startDaemonServer", () => {
     const addr = result.httpServer.address();
     expect(addr).toBeNull(); // Server unref'd after close
   });
+
+  it("shutdown completes when active SSE connections exist (issue #55)", async () => {
+    const mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 },
+    );
+    const addr = result.httpServer.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    // Track SSE connection lifecycle with separate promises
+    let onEstablished!: () => void;
+    const establishedPromise = new Promise<void>((r) => { onEstablished = r; });
+    let onClosed!: () => void;
+    const closedPromise = new Promise<void>((r) => { onClosed = r; });
+
+    const req = http.get(
+      { hostname: "127.0.0.1", port, path: "/sse" },
+      (res) => {
+        res.on("close", () => onClosed());
+        res.once("data", () => onEstablished());
+      },
+    );
+    req.on("error", (err) => {
+      // Ignore ECONNRESET — expected when server destroys the socket
+      if ((err as NodeJS.ErrnoException).code !== "ECONNRESET") {
+        throw err;
+      }
+    });
+
+    // Wait for SSE to fully establish (received initial endpoint event)
+    await establishedPromise;
+
+    // Shutdown should complete quickly, NOT hang indefinitely
+    const shutdownStart = Date.now();
+    await result.shutdown();
+    const shutdownDurationMs = Date.now() - shutdownStart;
+
+    // Verify: shutdown completed in < 1s (not stuck waiting for SSE to close)
+    expect(shutdownDurationMs).toBeLessThan(1000);
+
+    // Verify: SSE connection was force-closed by the server
+    await closedPromise;
+
+    // Verify: server is no longer listening
+    expect(result.httpServer.address()).toBeNull();
+  });
+
+  it("shutdown is idempotent — calling twice does not error", async () => {
+    const mockMcpServer = createMockMcpServer();
+    const result = await startDaemonServer(
+      mockMcpServer as unknown as Parameters<typeof startDaemonServer>[0],
+      { port: 0 },
+    );
+
+    await result.shutdown();
+    // Second call should resolve immediately, not throw
+    await result.shutdown();
+
+    expect(result.httpServer.address()).toBeNull();
+  });
 });

--- a/craig/src/daemon/daemon-server.ts
+++ b/craig/src/daemon/daemon-server.ts
@@ -18,6 +18,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type http from "node:http";
+import type { Socket } from "node:net";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -47,6 +48,9 @@ export interface DaemonServerResult {
 
 /** Default hostname — localhost only for security. */
 const DEFAULT_HOSTNAME = "127.0.0.1";
+
+/** Maximum time (ms) to wait for graceful shutdown before force-exiting. */
+const SHUTDOWN_TIMEOUT_MS = 5_000;
 
 /** Timestamp when the daemon started, for uptime calculation. */
 let startTime: number = Date.now();
@@ -269,6 +273,19 @@ export async function startDaemonServer(
   const handler = createRequestHandler(mcpServer);
   const httpServer = createServer(handler);
 
+  /**
+   * Track active TCP sockets so we can force-close them on shutdown.
+   * SSE connections are long-lived — httpServer.close() won't complete
+   * until they disconnect. Destroying sockets unblocks the close.
+   *
+   * [CLEAN-CODE] Socket lifecycle is managed in one place.
+   */
+  const activeSockets = new Set<Socket>();
+  httpServer.on("connection", (socket: Socket) => {
+    activeSockets.add(socket);
+    socket.once("close", () => activeSockets.delete(socket));
+  });
+
   await new Promise<void>((resolve, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(options.port, hostname, () => {
@@ -277,9 +294,34 @@ export async function startDaemonServer(
     });
   });
 
+  let isShuttingDown = false;
+
   const shutdown = async (): Promise<void> => {
-    await new Promise<void>((resolve, reject) => {
-      httpServer.close((err) => (err ? reject(err) : resolve()));
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    // 1. Force-close all active connections (SSE keep-alive prevents server.close())
+    for (const socket of activeSockets) {
+      socket.destroy();
+    }
+    activeSockets.clear();
+
+    // 2. Close the HTTP server (stop accepting new connections)
+    //    With sockets destroyed, this resolves immediately.
+    //    Timeout is a safety net in case something unexpected keeps the server alive.
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        console.error(
+          `[Craig] Shutdown timed out after ${SHUTDOWN_TIMEOUT_MS / 1000}s — forcing exit`,
+        );
+        resolve();
+      }, SHUTDOWN_TIMEOUT_MS);
+      timer.unref();
+
+      httpServer.close(() => {
+        clearTimeout(timer);
+        resolve();
+      });
     });
   };
 

--- a/craig/src/index.ts
+++ b/craig/src/index.ts
@@ -159,12 +159,32 @@ async function main(): Promise<void> {
       );
 
       // Graceful shutdown on SIGTERM/SIGINT (systemd, pm2, Ctrl+C)
+      let isShuttingDown = false;
+
       const handleShutdown = (): void => {
+        if (isShuttingDown) return;
+        isShuttingDown = true;
+
         console.error("[Craig] Shutting down daemon...");
-        void shutdown().then(() => {
-          console.error("[Craig] Daemon stopped.");
+
+        // Safety net: force exit if graceful shutdown hangs
+        const forceExitTimer = setTimeout(() => {
+          console.error("[Craig] Shutdown timed out — forcing exit");
           process.exit(0);
-        });
+        }, 5_000);
+
+        void shutdown()
+          .catch((err: unknown) => {
+            console.error(
+              "[Craig] Shutdown error:",
+              err instanceof Error ? err.message : String(err),
+            );
+          })
+          .finally(() => {
+            clearTimeout(forceExitTimer);
+            console.error("[Craig] Daemon stopped.");
+            process.exit(0);
+          });
       };
 
       process.on("SIGTERM", handleShutdown);


### PR DESCRIPTION
## Summary

Fixes the daemon shutdown hang when pressing Ctrl+C (SIGINT). The process would print `Shutting down daemon...` but never exit because `httpServer.close()` waits for all connections to end — and SSE connections are long-lived.

## Root Cause

`httpServer.close()` only stops accepting **new** connections. It waits for all **existing** connections to close before firing its callback. SSE (Server-Sent Events) connections are kept alive indefinitely, so the shutdown promise never resolved.

## Changes

### `craig/src/daemon/daemon-server.ts`
- **Track active TCP sockets** via `httpServer.on('connection')` — a `Set<Socket>` that auto-cleans on disconnect
- **Destroy all sockets on shutdown** — iterates the set and calls `socket.destroy()`, which unblocks `httpServer.close()`
- **Idempotency guard** — `isShuttingDown` flag prevents double-shutdown errors (`ERR_SERVER_NOT_RUNNING`)
- **Timeout safety net** — 5s `setTimeout` (with `.unref()`) resolves the promise if `server.close()` still hangs

### `craig/src/index.ts`
- **Idempotency guard** — prevents duplicate signal handlers from running
- **5s force-exit timeout** — `process.exit(0)` if graceful shutdown doesn't complete
- **Error handling** — `.catch()` prevents unhandled promise rejection; `.finally()` ensures exit

### `craig/src/daemon/__tests__/daemon-server.test.ts`
- **`shutdown completes when active SSE connections exist`** — establishes a live SSE connection, calls `shutdown()`, asserts it completes in <1s and the connection is force-closed
- **`shutdown is idempotent`** — calls `shutdown()` twice, asserts no error on second call

## Test Results

```
Test Files  32 passed (32)
     Tests  789 passed (789)
```

Closes #55