### PR TITLE
feat(craig): add craig_shutdown MCP tool for graceful daemon shutdown

### DIFF
--- a/craig/src/core/__tests__/mcp-server.test.ts
+++ b/craig/src/core/__tests__/mcp-server.test.ts
@@ -32,7 +32,7 @@ describe("createCraigServer", () => {
     expect(server).toHaveProperty("close");
   });
 
-  it("registers all 6 tools", () => {
+  it("registers all 7 tools", () => {
     const server = createCraigServer({
       state: createMockState(),
       config: createMockConfig(),
@@ -50,12 +50,13 @@ describe("createCraigServer", () => {
       "craig_schedule",
       "craig_config",
       "craig_digest",
+      "craig_shutdown",
     ];
 
     for (const toolName of expectedTools) {
       expect(registeredTools).toHaveProperty(toolName);
     }
 
-    expect(Object.keys(registeredTools)).toHaveLength(6);
+    expect(Object.keys(registeredTools)).toHaveLength(7);
   });
 });

--- a/craig/src/core/__tests__/shutdown-handler.test.ts
+++ b/craig/src/core/__tests__/shutdown-handler.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Unit tests for the craig_shutdown tool handler.
+ *
+ * Tests written FIRST per TDD — each acceptance criterion from issue #54
+ * maps to one or more tests.
+ *
+ * AC1: Daemon mode — stops scheduler, merge watcher, flushes state, exits cleanly
+ * AC2: Stdio mode — logs warning, does not exit
+ * AC3: Pending tasks — waits up to 30s for completion before force exit
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/54
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { createShutdownHandler } from "../tool-handlers.js";
+import type { StatePort } from "../../state/index.js";
+import type { ShutdownResult, ToolError } from "../core.types.js";
+import { createMockState } from "./mock-factories.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Create a minimal mock object with a stop() method. */
+function createMockStoppable(): { stop: ReturnType<typeof vi.fn> } {
+  return { stop: vi.fn() };
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC2: Stdio mode — logs warning, lifecycle managed by CLI           */
+/* ------------------------------------------------------------------ */
+
+describe("craig_shutdown handler — stdio mode", () => {
+  let state: StatePort;
+  let handler: ReturnType<typeof createShutdownHandler>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state = createMockState();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    handler = createShutdownHandler(state, { mode: "stdio" });
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns status "ignored" with warning message', async () => {
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("ignored");
+    expect(result.message).toContain("stdio");
+  });
+
+  it("logs a warning to stderr", async () => {
+    await handler();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("stdio"),
+    );
+  });
+
+  it("does not stop scheduler or merge watcher", async () => {
+    const scheduler = createMockStoppable();
+    const mergeWatcher = createMockStoppable();
+    handler = createShutdownHandler(state, {
+      mode: "stdio",
+      scheduler,
+      mergeWatcher,
+    });
+
+    await handler();
+
+    expect(scheduler.stop).not.toHaveBeenCalled();
+    expect(mergeWatcher.stop).not.toHaveBeenCalled();
+  });
+
+  it("does not flush state", async () => {
+    await handler();
+
+    expect(state.save).not.toHaveBeenCalled();
+  });
+
+  it("includes reason in warning log when provided", async () => {
+    await handler({ reason: "user requested" });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("user requested"),
+    );
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC1: Daemon mode — graceful shutdown                               */
+/* ------------------------------------------------------------------ */
+
+describe("craig_shutdown handler — daemon mode", () => {
+  let state: StatePort;
+  let scheduler: ReturnType<typeof createMockStoppable>;
+  let mergeWatcher: ReturnType<typeof createMockStoppable>;
+  let onShutdown: ReturnType<typeof vi.fn>;
+  let handler: ReturnType<typeof createShutdownHandler>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    state = createMockState();
+    vi.mocked(state.get).mockReturnValue([] as never);
+    scheduler = createMockStoppable();
+    mergeWatcher = createMockStoppable();
+    onShutdown = vi.fn().mockResolvedValue(undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    handler = createShutdownHandler(state, {
+      mode: "daemon",
+      scheduler,
+      mergeWatcher,
+      onShutdown,
+    });
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns status "shutting_down" immediately', async () => {
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+    expect(result.message).toBeDefined();
+  });
+
+  it("stops the scheduler", async () => {
+    await handler();
+
+    await vi.waitFor(() => {
+      expect(scheduler.stop).toHaveBeenCalled();
+    });
+  });
+
+  it("stops the merge watcher", async () => {
+    await handler();
+
+    await vi.waitFor(() => {
+      expect(mergeWatcher.stop).toHaveBeenCalled();
+    });
+  });
+
+  it("flushes state to disk", async () => {
+    await handler();
+
+    await vi.waitFor(() => {
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+
+  it("calls onShutdown callback", async () => {
+    await handler();
+
+    await vi.waitFor(() => {
+      expect(onShutdown).toHaveBeenCalled();
+    });
+  });
+
+  it("includes reason in the response message when provided", async () => {
+    const result = (await handler({ reason: "maintenance" })) as ShutdownResult;
+
+    expect(result.message).toContain("maintenance");
+  });
+
+  it("logs the shutdown reason to stderr", async () => {
+    await handler({ reason: "deployment" });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("deployment"),
+    );
+  });
+
+  it("works without optional scheduler", async () => {
+    handler = createShutdownHandler(state, {
+      mode: "daemon",
+      mergeWatcher,
+      onShutdown,
+    });
+
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+  });
+
+  it("works without optional merge watcher", async () => {
+    handler = createShutdownHandler(state, {
+      mode: "daemon",
+      scheduler,
+      onShutdown,
+    });
+
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+  });
+
+  it("works without onShutdown callback", async () => {
+    handler = createShutdownHandler(state, {
+      mode: "daemon",
+      scheduler,
+      mergeWatcher,
+    });
+
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+    await vi.waitFor(() => {
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  AC3: Pending tasks — wait up to 30s before force exit              */
+/* ------------------------------------------------------------------ */
+
+describe("craig_shutdown handler — pending task drain", () => {
+  let state: StatePort;
+  let onShutdown: ReturnType<typeof vi.fn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    state = createMockState();
+    onShutdown = vi.fn().mockResolvedValue(undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    errorSpy.mockRestore();
+  });
+
+  it("waits for running tasks to complete before flushing", async () => {
+    // First call: tasks running. Second call: tasks done.
+    let callCount = 0;
+    vi.mocked(state.get).mockImplementation(<K extends string>(key: K) => {
+      if (key === "running_tasks") {
+        callCount++;
+        return (callCount <= 2 ? ["security_scan"] : []) as never;
+      }
+      return [] as never;
+    });
+
+    const handler = createShutdownHandler(state, {
+      mode: "daemon",
+      onShutdown,
+    });
+
+    const resultPromise = handler();
+    const result = await resultPromise;
+
+    expect((result as ShutdownResult).status).toBe("shutting_down");
+
+    // Advance time to allow the drain loop to run
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await vi.waitFor(() => {
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+
+  it("force-exits after 30s timeout when tasks never complete", async () => {
+    // Tasks never clear
+    vi.mocked(state.get).mockReturnValue(["stuck_task"] as never);
+
+    const handler = createShutdownHandler(state, {
+      mode: "daemon",
+      onShutdown,
+    });
+
+    await handler();
+
+    // Advance past the 30s timeout
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("timed out"),
+      );
+    });
+
+    // State should still be flushed even on timeout
+    expect(state.save).toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Error handling — shutdown handler never throws                     */
+/* ------------------------------------------------------------------ */
+
+describe("craig_shutdown handler — error resilience", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("returns shutting_down even when state.get throws during async shutdown", async () => {
+    const state = createMockState();
+    vi.mocked(state.get).mockImplementation(() => {
+      throw new Error("State corrupted");
+    });
+
+    const handler = createShutdownHandler(state, {
+      mode: "daemon",
+    });
+
+    // The handler returns immediately — errors in async shutdown are logged, not returned
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+  });
+
+  it("continues shutdown even if scheduler.stop() throws", async () => {
+    const state = createMockState();
+    vi.mocked(state.get).mockReturnValue([] as never);
+    const scheduler = { stop: vi.fn().mockImplementation(() => { throw new Error("Cron error"); }) };
+    const onShutdown = vi.fn().mockResolvedValue(undefined);
+
+    const handler = createShutdownHandler(state, {
+      mode: "daemon",
+      scheduler,
+      onShutdown,
+    });
+
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+
+    // Shutdown should still proceed despite scheduler error
+    await vi.waitFor(() => {
+      expect(state.save).toHaveBeenCalled();
+    });
+  });
+
+  it("continues shutdown even if state.save() rejects", async () => {
+    const state = createMockState();
+    vi.mocked(state.get).mockReturnValue([] as never);
+    vi.mocked(state.save).mockRejectedValue(new Error("Write failed"));
+    const onShutdown = vi.fn().mockResolvedValue(undefined);
+
+    const handler = createShutdownHandler(state, {
+      mode: "daemon",
+      onShutdown,
+    });
+
+    const result = (await handler()) as ShutdownResult;
+
+    expect(result.status).toBe("shutting_down");
+
+    await vi.waitFor(() => {
+      expect(onShutdown).toHaveBeenCalled();
+    });
+  });
+});

--- a/craig/src/core/core.types.ts
+++ b/craig/src/core/core.types.ts
@@ -128,3 +128,19 @@ export interface DigestParams {
 export interface StatusParams {
   readonly repo?: string;
 }
+
+/** Input parameters for craig_shutdown. */
+export interface ShutdownParams {
+  readonly reason?: string;
+}
+
+/**
+ * Return type for craig_shutdown.
+ *
+ * "shutting_down" — daemon mode: graceful shutdown initiated.
+ * "ignored" — stdio mode: lifecycle managed by CLI, no action taken.
+ */
+export interface ShutdownResult {
+  readonly status: "shutting_down" | "ignored";
+  readonly message: string;
+}

--- a/craig/src/core/index.ts
+++ b/craig/src/core/index.ts
@@ -16,7 +16,9 @@ export {
   createScheduleHandler,
   createConfigHandler,
   createDigestHandler,
+  createShutdownHandler,
 } from "./tool-handlers.js";
+export type { ShutdownHandlerOpts, Stoppable } from "./tool-handlers.js";
 export type {
   StatusResult,
   RunTaskSuccess,
@@ -24,6 +26,7 @@ export type {
   ScheduleResult,
   ConfigResult,
   DigestResult,
+  ShutdownResult,
   ToolError,
   RunTaskParams,
   FindingsParams,
@@ -31,6 +34,7 @@ export type {
   ConfigParams,
   DigestParams,
   StatusParams,
+  ShutdownParams,
   ValidTask,
 } from "./core.types.js";
 export { VALID_TASKS, isValidTask } from "./core.types.js";

--- a/craig/src/core/mcp-server.ts
+++ b/craig/src/core/mcp-server.ts
@@ -1,7 +1,7 @@
 /**
  * Craig MCP Server — Factory and tool registration.
  *
- * Creates an MCP server with 6 tools registered, each delegating
+ * Creates an MCP server with 7 tools registered, each delegating
  * to the appropriate component via thin handler functions.
  *
  * [HEXAGONAL] The MCP server is an adapter — it adapts the MCP protocol
@@ -27,7 +27,9 @@ import {
   createScheduleHandler,
   createConfigHandler,
   createDigestHandler,
+  createShutdownHandler,
 } from "./tool-handlers.js";
+import type { ShutdownHandlerOpts } from "./tool-handlers.js";
 
 /* ------------------------------------------------------------------ */
 /*  Dependencies Interface                                             */
@@ -48,6 +50,8 @@ export interface CraigServerDeps {
   readonly copilot: CopilotPort;
   readonly repoManager?: RepoManagerPort;
   readonly registry?: AnalyzerRegistry;
+  /** Shutdown options for the craig_shutdown tool. */
+  readonly shutdown?: ShutdownHandlerOpts;
 }
 
 /* ------------------------------------------------------------------ */
@@ -55,7 +59,7 @@ export interface CraigServerDeps {
 /* ------------------------------------------------------------------ */
 
 /**
- * Create and configure the Craig MCP server with all 6 tools registered.
+ * Create and configure the Craig MCP server with all 7 tools registered.
  *
  * The server is ready to be connected to a transport (StdioServerTransport
  * for CLI usage). Does NOT start the server — caller decides transport.
@@ -78,6 +82,7 @@ export function createCraigServer(deps: CraigServerDeps): McpServer {
   registerScheduleTool(server, deps);
   registerConfigTool(server, deps);
   registerDigestTool(server, deps);
+  registerShutdownTool(server, deps);
 
   return server;
 }
@@ -249,6 +254,31 @@ function registerDigestTool(server: McpServer, deps: CraigServerDeps): void {
     async (args) => {
       const result = await handler(args);
       return wrapToolResult(result);
+    },
+  );
+}
+
+/**
+ * Register craig_shutdown — gracefully shut down the Craig daemon.
+ * In stdio mode, logs a warning (lifecycle managed by CLI).
+ * In daemon mode, stops all background services and exits.
+ *
+ * @see https://github.com/vbomfim/sdlc-guardian-agents/issues/54
+ */
+function registerShutdownTool(server: McpServer, deps: CraigServerDeps): void {
+  const shutdownOpts: ShutdownHandlerOpts = deps.shutdown ?? { mode: "stdio" };
+  const handler = createShutdownHandler(deps.state, shutdownOpts);
+
+  server.tool(
+    "craig_shutdown",
+    "Gracefully shut down the Craig daemon. Stops scheduler, merge watcher, flushes state, and exits.",
+    {
+      reason: z.string().optional(),
+    },
+    async (args) => {
+      const result = await handler(args);
+      const isError = "error" in result;
+      return wrapToolResult(result, isError);
     },
   );
 }

--- a/craig/src/core/tool-handlers.ts
+++ b/craig/src/core/tool-handlers.ts
@@ -28,6 +28,7 @@ import type {
   ScheduleResult,
   ConfigResult,
   DigestResult,
+  ShutdownResult,
   ToolError,
   RunTaskParams,
   FindingsParams,
@@ -35,6 +36,7 @@ import type {
   ConfigParams,
   DigestParams,
   StatusParams,
+  ShutdownParams,
 } from "./core.types.js";
 import { isValidTask } from "./core.types.js";
 import { sanitizeError } from "./error-sanitizer.js";
@@ -322,6 +324,221 @@ export function createDigestHandler(
       return createToolError(error);
     }
   };
+}
+
+/* ------------------------------------------------------------------ */
+/*  craig_shutdown                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Minimal interface for components that can be stopped.
+ *
+ * [SOLID/ISP] Handlers depend only on what they need — a stop() method.
+ * Both SchedulerPort and MergeWatcherPort satisfy this interface.
+ */
+export interface Stoppable {
+  stop(): void;
+}
+
+/**
+ * Options for the shutdown handler.
+ *
+ * [HEXAGONAL] These are injected dependencies — the handler doesn't
+ * know about concrete adapters.
+ */
+export interface ShutdownHandlerOpts {
+  /** Transport mode: "daemon" or "stdio". */
+  readonly mode: "daemon" | "stdio";
+  /** Scheduler to stop on shutdown. */
+  readonly scheduler?: Stoppable;
+  /** Merge watcher to stop on shutdown. */
+  readonly mergeWatcher?: Stoppable;
+  /** Callback to shut down the daemon HTTP server. */
+  readonly onShutdown?: () => Promise<void>;
+}
+
+/** Maximum time (ms) to wait for running tasks to drain. */
+const DRAIN_TIMEOUT_MS = 30_000;
+
+/** Polling interval (ms) to check for running tasks during drain. */
+const DRAIN_POLL_MS = 1_000;
+
+/**
+ * Create the handler for the craig_shutdown tool.
+ *
+ * In stdio mode: logs a warning and returns "ignored" — the CLI manages
+ * the process lifecycle.
+ *
+ * In daemon mode: initiates graceful shutdown asynchronously:
+ * 1. Stops scheduler and merge watcher
+ * 2. Waits up to 30s for pending tasks to complete
+ * 3. Flushes state to disk
+ * 4. Calls onShutdown callback (HTTP server teardown)
+ * 5. Exits the process
+ *
+ * The response is returned immediately so the MCP client receives
+ * the acknowledgement before the process exits.
+ *
+ * [HEXAGONAL] Adapter layer — orchestrates shutdown via injected ports.
+ * [CLEAN-CODE] Fire-and-forget async shutdown, same pattern as run_task.
+ * [AC1] Daemon mode: stops all background services, exits cleanly.
+ * [AC2] Stdio mode: logs warning, no action.
+ * [AC3] Waits up to 30s for pending tasks before force exit.
+ *
+ * @param state - State port for flushing and checking running tasks.
+ * @param opts - Shutdown dependencies (mode, stoppables, callback).
+ */
+export function createShutdownHandler(
+  state: StatePort,
+  opts: ShutdownHandlerOpts,
+): (params?: ShutdownParams) => Promise<ShutdownResult | ToolError> {
+  return async (params) => {
+    try {
+      const reason = params?.reason;
+      const reasonSuffix = reason ? ` (reason: ${reason})` : "";
+
+      // Stdio mode: lifecycle managed by CLI — warn and return [AC2]
+      if (opts.mode === "stdio") {
+        const message =
+          `Shutdown ignored in stdio mode — lifecycle is managed by the CLI.${reasonSuffix}`;
+        console.error(`[Craig] ${message}`);
+        return { status: "ignored" as const, message };
+      }
+
+      // Daemon mode: initiate graceful shutdown [AC1]
+      const message = `Graceful shutdown initiated.${reasonSuffix}`;
+      console.error(`[Craig] Shutting down...${reasonSuffix}`);
+
+      // Fire-and-forget: shutdown runs asynchronously after response
+      void performGracefulShutdown(state, opts, reason);
+
+      return { status: "shutting_down" as const, message };
+    } catch (error: unknown) {
+      return createToolError(error);
+    }
+  };
+}
+
+/**
+ * Execute the graceful shutdown sequence.
+ *
+ * Order:
+ * 1. Stop scheduler and merge watcher (stop accepting new work)
+ * 2. Drain running tasks (wait up to 30s) [AC3]
+ * 3. Flush state to disk
+ * 4. Call onShutdown callback (HTTP server teardown + process exit)
+ *
+ * Each step is resilient — errors are caught and logged,
+ * and the sequence continues to the next step.
+ *
+ * [HEXAGONAL] Does NOT call process.exit() — the composition root
+ * provides an onShutdown callback that handles process termination.
+ * [CLEAN-CODE] Each step isolated, errors don't cascade.
+ * [SECURITY] Logs to stderr — stdout is MCP JSON-RPC.
+ */
+async function performGracefulShutdown(
+  state: StatePort,
+  opts: ShutdownHandlerOpts,
+  _reason?: string,
+): Promise<void> {
+  try {
+    // 1. Stop background services
+    stopSafely(opts.scheduler, "scheduler");
+    stopSafely(opts.mergeWatcher, "merge watcher");
+
+    // 2. Wait for running tasks to drain [AC3]
+    await drainRunningTasks(state);
+
+    // 3. Flush state
+    try {
+      await state.save();
+      console.error("[Craig] State flushed to disk.");
+    } catch (error: unknown) {
+      console.error(
+        "[Craig] State flush failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    // 4. Tear down HTTP server + exit (delegated to composition root)
+    if (opts.onShutdown) {
+      try {
+        await opts.onShutdown();
+      } catch (error: unknown) {
+        console.error(
+          "[Craig] onShutdown callback failed:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    console.error("[Craig] Shutdown complete.");
+  } catch (error: unknown) {
+    // Catch-all: prevent unhandled rejections during shutdown
+    console.error(
+      "[Craig] Shutdown error:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+/**
+ * Stop a component safely — catch and log errors.
+ *
+ * [CLEAN-CODE] Never let a stop() failure prevent the rest of shutdown.
+ */
+function stopSafely(component: Stoppable | undefined, name: string): void {
+  if (!component) return;
+  try {
+    component.stop();
+    console.error(`[Craig] Stopped ${name}.`);
+  } catch (error: unknown) {
+    console.error(
+      `[Craig] Failed to stop ${name}:`,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+/**
+ * Wait for all running tasks to complete, up to DRAIN_TIMEOUT_MS.
+ *
+ * Polls state.get("running_tasks") every DRAIN_POLL_MS. If tasks
+ * are still running after the timeout, logs a warning and proceeds.
+ *
+ * [AC3] Waits up to 30s for completion before force exit.
+ */
+async function drainRunningTasks(state: StatePort): Promise<void> {
+  const runningTasks = state.get("running_tasks");
+  if (runningTasks.length === 0) return;
+
+  console.error(
+    `[Craig] Waiting for ${runningTasks.length} running task(s) to complete...`,
+  );
+
+  const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const current = state.get("running_tasks");
+    if (current.length === 0) {
+      console.error("[Craig] All tasks completed.");
+      return;
+    }
+    await sleep(DRAIN_POLL_MS);
+  }
+
+  const remaining = state.get("running_tasks");
+  console.error(
+    `[Craig] Drain timed out — ${remaining.length} task(s) still running. Proceeding with shutdown.`,
+  );
+}
+
+/**
+ * Sleep for the specified number of milliseconds.
+ * Extracted for testability with fake timers.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /* ------------------------------------------------------------------ */

--- a/craig/src/index.ts
+++ b/craig/src/index.ts
@@ -157,14 +157,33 @@ async function main(): Promise<void> {
     const registry = createAnalyzerRegistry(analyzers);
     console.error(`[Craig] ${registry.size} analyzers registered`);
 
-    // 9. Create and configure MCP server
-    const server = createCraigServer({ state, config, copilot, repoManager, registry });
+    // 9. Build shutdown deps for the craig_shutdown MCP tool.
+    //    In daemon mode, onShutdown is deferred — set after startDaemonServer().
+    //    [CLEAN-CODE] Deferred callback pattern: closure captures the ref.
+    const shutdownRef: { fn?: () => Promise<void> } = {};
+    const shutdownDeps = {
+      mode: (args.daemon ? "daemon" : "stdio") as "daemon" | "stdio",
+      onShutdown: async (): Promise<void> => {
+        await shutdownRef.fn?.();
+        console.error("[Craig] Daemon stopped.");
+        process.exit(0);
+      },
+    };
+
+    // 10. Create and configure MCP server
+    const server = createCraigServer({
+      state, config, copilot, repoManager, registry,
+      shutdown: shutdownDeps,
+    });
 
     if (args.daemon) {
       // 6b. Daemon mode: SSE transport over HTTP
       const { shutdown } = await startDaemonServer(server, {
         port: args.port,
       });
+
+      // Wire the deferred shutdown callback for craig_shutdown tool
+      shutdownRef.fn = shutdown;
 
       console.error(
         `[Craig] Daemon mode: listening on http://127.0.0.1:${args.port}`,


### PR DESCRIPTION
## Summary

Implements `craig_shutdown` MCP tool for graceful daemon shutdown.

Closes #54

## What was implemented

New MCP tool: `craig_shutdown` — the 7th Craig tool.

### Daemon mode (`--daemon`)
1. **Stops** scheduler and merge watcher
2. **Drains** pending tasks (polls every 1s, up to 30s timeout)
3. **Flushes** state to disk
4. **Calls** onShutdown callback (HTTP server teardown + process exit)
5. Returns `{ status: "shutting_down", message: "..." }` immediately

### Stdio mode (default)
- Logs a warning: lifecycle is managed by the CLI
- Returns `{ status: "ignored", message: "..." }`

### Parameters
| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| reason | string | No | Optional reason logged to stderr |

## Files changed

| File | Change | Why |
|------|--------|-----|
| `core/core.types.ts` | +`ShutdownParams`, +`ShutdownResult` | Type definitions for the new tool |
| `core/tool-handlers.ts` | +`createShutdownHandler`, +`Stoppable`, +`ShutdownHandlerOpts` | Handler factory with async shutdown orchestration |
| `core/mcp-server.ts` | +`registerShutdownTool`, updated `CraigServerDeps` | Tool registration with zod schema |
| `core/index.ts` | Updated barrel exports | Export new types and handler |
| `index.ts` | Wired shutdown deps with deferred callback pattern | Composition root wiring |
| `core/__tests__/shutdown-handler.test.ts` | **NEW** — 20 tests | Full TDD coverage |
| `core/__tests__/mcp-server.test.ts` | Updated tool count 6→7 | Reflect new tool registration |

## Design Decisions

| # | Decision | Rationale | Reversible? |
|---|----------|-----------|-------------|
| 1 | Fire-and-forget async shutdown (same pattern as run_task) | MCP response must go back before process exits | No — required by MCP protocol |
| 2 | `process.exit()` in composition root, not handler | [HEXAGONAL] handlers shouldn't know about process lifecycle | Yes |
| 3 | `Stoppable` interface instead of full SchedulerPort/MergeWatcherPort | [SOLID/ISP] handler only needs stop() | Yes |
| 4 | Deferred callback pattern for onShutdown | Server created before daemon starts (circular dep) | Yes |
| 5 | 30s drain timeout with 1s polling | Matches AC3 requirement exactly | Yes — change constants |

## Tests

- [x] 20 unit tests, all passing (971 total)
- [x] TypeScript strict compilation — 0 errors
- [x] All 3 acceptance criteria covered:
  - AC1: Daemon mode graceful shutdown (7 tests)
  - AC2: Stdio mode warning (5 tests)
  - AC3: Pending task drain with 30s timeout (2 tests)
  - Error resilience (3 tests)
  - Edge cases: missing optional deps (3 tests)