### PR TITLE
feat: GitOpsPort adapter with worktree isolation — enable auto_develop

### DIFF
--- a/craig/src/git-ops/__tests__/git-ops.adapter.test.ts
+++ b/craig/src/git-ops/__tests__/git-ops.adapter.test.ts
@@ -1,0 +1,490 @@
+/**
+ * GitOpsAdapter — Unit Tests
+ *
+ * Tests for the worktree-based git operations adapter.
+ * All child_process.execFile calls are mocked to avoid real git operations.
+ *
+ * Test categories:
+ * - createWorktree: creates worktree with correct args, returns path
+ * - commitFiles: writes files, stages, commits, returns SHA
+ * - push: pushes branch to origin
+ * - removeWorktree: removes worktree with --force
+ * - toAnalyzerGitOps bridge: adapts worktree API to stateful GitOpsPort
+ * - Error handling: rejects on git failures, provides context
+ * - Security: uses execFile (not exec) for injection safety
+ *
+ * [TDD] Written BEFORE implementation — Red phase.
+ *
+ * @module git-ops/__tests__
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be before imports
+// ---------------------------------------------------------------------------
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("node:crypto", () => ({
+  randomUUID: vi.fn().mockReturnValue("test-uuid-1234"),
+}));
+
+import { execFile } from "node:child_process";
+import { writeFile, mkdir } from "node:fs/promises";
+import { GitOpsAdapter } from "../git-ops.adapter.js";
+import { toAnalyzerGitOps } from "../index.js";
+import type { GitOpsPort } from "../git-ops.port.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Configure the mocked execFile to resolve with given stdout/stderr.
+ *
+ * child_process.execFile uses a callback signature:
+ *   execFile(file, args, options, callback)
+ *
+ * Our adapter wraps it with util.promisify, so the mock must call the
+ * callback with (null, { stdout, stderr }).
+ */
+function mockExecFileSuccess(stdout = "", stderr = ""): void {
+  (execFile as unknown as Mock).mockImplementation(
+    (
+      _file: string,
+      _args: string[],
+      _opts: Record<string, unknown>,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout, stderr });
+    },
+  );
+}
+
+function mockExecFileFailure(message: string): void {
+  (execFile as unknown as Mock).mockImplementation(
+    (
+      _file: string,
+      _args: string[],
+      _opts: Record<string, unknown>,
+      cb: (err: Error | null) => void,
+    ) => {
+      cb(new Error(message));
+    },
+  );
+}
+
+/**
+ * mockExecFileSequence — configure sequential execFile responses.
+ *
+ * Each call to execFile will use the next response in the list.
+ * Useful for testing multi-step operations like commitFiles
+ * (which calls git add then git commit then git rev-parse).
+ */
+function mockExecFileSequence(
+  responses: Array<{ stdout?: string; stderr?: string; error?: string }>,
+): void {
+  let callIndex = 0;
+  (execFile as unknown as Mock).mockImplementation(
+    (
+      _file: string,
+      _args: string[],
+      _opts: Record<string, unknown>,
+      cb: (
+        err: Error | null,
+        result?: { stdout: string; stderr: string },
+      ) => void,
+    ) => {
+      const response = responses[callIndex] ?? { stdout: "" };
+      callIndex++;
+      if (response.error) {
+        cb(new Error(response.error));
+      } else {
+        cb(null, { stdout: response.stdout ?? "", stderr: response.stderr ?? "" });
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GitOpsAdapter — createWorktree
+// ---------------------------------------------------------------------------
+
+describe("GitOpsAdapter", () => {
+  let adapter: GitOpsAdapter;
+  const REPO_ROOT = "/repo";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new GitOpsAdapter(REPO_ROOT);
+  });
+
+  describe("createWorktree", () => {
+    it("calls git worktree add with correct arguments", async () => {
+      mockExecFileSuccess();
+
+      await adapter.createWorktree("craig/fix-001", "main");
+
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["worktree", "add", "/tmp/craig-test-uuid-1234", "-b", "craig/fix-001", "main"],
+        { cwd: REPO_ROOT },
+        expect.any(Function),
+      );
+    });
+
+    it("returns the worktree path", async () => {
+      mockExecFileSuccess();
+
+      const path = await adapter.createWorktree("craig/fix-001", "main");
+
+      expect(path).toBe("/tmp/craig-test-uuid-1234");
+    });
+
+    it("uses unique UUID for each worktree", async () => {
+      mockExecFileSuccess();
+      const { randomUUID } = await import("node:crypto");
+
+      (randomUUID as Mock)
+        .mockReturnValueOnce("uuid-aaa")
+        .mockReturnValueOnce("uuid-bbb");
+
+      const path1 = await adapter.createWorktree("branch-a", "main");
+      const path2 = await adapter.createWorktree("branch-b", "main");
+
+      expect(path1).toBe("/tmp/craig-uuid-aaa");
+      expect(path2).toBe("/tmp/craig-uuid-bbb");
+    });
+
+    it("rejects when git worktree add fails", async () => {
+      mockExecFileFailure("fatal: branch already exists");
+
+      await expect(
+        adapter.createWorktree("existing-branch", "main"),
+      ).rejects.toThrow("fatal: branch already exists");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // commitFiles
+  // -------------------------------------------------------------------------
+
+  describe("commitFiles", () => {
+    it("writes each file to the worktree directory", async () => {
+      mockExecFileSequence([
+        { stdout: "" },                   // git add .
+        { stdout: "" },                   // git commit
+        { stdout: "abc123def456\n" },     // git rev-parse HEAD
+      ]);
+
+      const files = new Map<string, string>([
+        ["src/fix.ts", 'console.log("fixed");'],
+        ["tests/fix.test.ts", 'test("it works", () => {});'],
+      ]);
+
+      await adapter.commitFiles("/tmp/craig-wt", files, "fix: patch");
+
+      expect(writeFile).toHaveBeenCalledWith(
+        "/tmp/craig-wt/src/fix.ts",
+        'console.log("fixed");',
+        "utf-8",
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        "/tmp/craig-wt/tests/fix.test.ts",
+        'test("it works", () => {});',
+        "utf-8",
+      );
+    });
+
+    it("creates parent directories for nested files", async () => {
+      mockExecFileSequence([
+        { stdout: "" },
+        { stdout: "" },
+        { stdout: "sha1\n" },
+      ]);
+
+      const files = new Map<string, string>([
+        ["src/deep/nested/file.ts", "content"],
+      ]);
+
+      await adapter.commitFiles("/tmp/craig-wt", files, "fix: nested");
+
+      expect(mkdir).toHaveBeenCalledWith("/tmp/craig-wt/src/deep/nested", {
+        recursive: true,
+      });
+    });
+
+    it("stages all changes with git add", async () => {
+      mockExecFileSequence([
+        { stdout: "" },                   // git add .
+        { stdout: "" },                   // git commit
+        { stdout: "sha1\n" },             // git rev-parse HEAD
+      ]);
+
+      await adapter.commitFiles(
+        "/tmp/craig-wt",
+        new Map([["a.ts", "x"]]),
+        "msg",
+      );
+
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["add", "."],
+        { cwd: "/tmp/craig-wt" },
+        expect.any(Function),
+      );
+    });
+
+    it("commits with the provided message", async () => {
+      mockExecFileSequence([
+        { stdout: "" },
+        { stdout: "" },
+        { stdout: "sha1\n" },
+      ]);
+
+      await adapter.commitFiles(
+        "/tmp/craig-wt",
+        new Map([["a.ts", "x"]]),
+        "fix: address critical SQL injection",
+      );
+
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["commit", "-m", "fix: address critical SQL injection"],
+        { cwd: "/tmp/craig-wt" },
+        expect.any(Function),
+      );
+    });
+
+    it("returns the commit SHA (trimmed)", async () => {
+      mockExecFileSequence([
+        { stdout: "" },
+        { stdout: "" },
+        { stdout: "  abc123def456  \n" },
+      ]);
+
+      const sha = await adapter.commitFiles(
+        "/tmp/craig-wt",
+        new Map([["a.ts", "x"]]),
+        "msg",
+      );
+
+      expect(sha).toBe("abc123def456");
+    });
+
+    it("rejects when git commit fails", async () => {
+      mockExecFileSequence([
+        { stdout: "" },                       // git add succeeds
+        { error: "nothing to commit" },       // git commit fails
+      ]);
+
+      await expect(
+        adapter.commitFiles("/tmp/craig-wt", new Map([["a.ts", "x"]]), "msg"),
+      ).rejects.toThrow("nothing to commit");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // push
+  // -------------------------------------------------------------------------
+
+  describe("push", () => {
+    it("calls git push origin with branch name", async () => {
+      mockExecFileSuccess();
+
+      await adapter.push("/tmp/craig-wt", "craig/fix-001");
+
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["push", "origin", "craig/fix-001"],
+        { cwd: "/tmp/craig-wt" },
+        expect.any(Function),
+      );
+    });
+
+    it("rejects when push fails", async () => {
+      mockExecFileFailure("rejected: non-fast-forward");
+
+      await expect(
+        adapter.push("/tmp/craig-wt", "craig/fix-001"),
+      ).rejects.toThrow("rejected: non-fast-forward");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // removeWorktree
+  // -------------------------------------------------------------------------
+
+  describe("removeWorktree", () => {
+    it("calls git worktree remove with --force", async () => {
+      mockExecFileSuccess();
+
+      await adapter.removeWorktree("/tmp/craig-wt");
+
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["worktree", "remove", "/tmp/craig-wt", "--force"],
+        { cwd: REPO_ROOT },
+        expect.any(Function),
+      );
+    });
+
+    it("rejects when remove fails", async () => {
+      mockExecFileFailure("not a valid worktree");
+
+      await expect(
+        adapter.removeWorktree("/tmp/craig-wt"),
+      ).rejects.toThrow("not a valid worktree");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAnalyzerGitOps — Bridge to auto-fix/auto-develop GitOpsPort
+// ---------------------------------------------------------------------------
+
+describe("toAnalyzerGitOps", () => {
+  const BASE_BRANCH = "main";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: bridge's internal execFile calls succeed with empty output
+    mockExecFileSuccess("");
+  });
+
+  function createMockAdapter(): GitOpsPort {
+    return {
+      createWorktree: vi.fn<GitOpsPort["createWorktree"]>().mockResolvedValue("/tmp/craig-mock-wt"),
+      commitFiles: vi.fn<GitOpsPort["commitFiles"]>().mockResolvedValue("sha-abc"),
+      push: vi.fn<GitOpsPort["push"]>().mockResolvedValue(undefined),
+      removeWorktree: vi.fn<GitOpsPort["removeWorktree"]>().mockResolvedValue(undefined),
+    };
+  }
+
+  describe("createBranch", () => {
+    it("delegates to adapter.createWorktree with baseBranch", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await bridge.createBranch("craig/fix-001");
+
+      expect(mock.createWorktree).toHaveBeenCalledWith("craig/fix-001", "main");
+    });
+  });
+
+  describe("hasChanges", () => {
+    it("returns false when no worktree is active", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      const result = await bridge.hasChanges();
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when worktree has uncommitted changes", async () => {
+      mockExecFileSuccess(" M src/db.py\n");
+
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await bridge.createBranch("craig/fix-001");
+
+      const result = await bridge.hasChanges();
+
+      expect(result).toBe(true);
+      expect(execFile).toHaveBeenCalledWith(
+        "git",
+        ["status", "--porcelain"],
+        { cwd: "/tmp/craig-mock-wt" },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe("getChangedFiles", () => {
+    it("returns empty array when no worktree is active", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      const result = await bridge.getChangedFiles();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("commitAll", () => {
+    it("throws when no worktree is active", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await expect(bridge.commitAll("msg")).rejects.toThrow(
+        "No active worktree",
+      );
+    });
+  });
+
+  describe("push", () => {
+    it("delegates to adapter.push with worktree path and branch", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await bridge.createBranch("craig/fix-001");
+      await bridge.push("craig/fix-001");
+
+      expect(mock.push).toHaveBeenCalledWith("/tmp/craig-mock-wt", "craig/fix-001");
+    });
+
+    it("throws when no worktree is active", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await expect(bridge.push("craig/fix-001")).rejects.toThrow(
+        "No active worktree",
+      );
+    });
+  });
+
+  describe("cleanup", () => {
+    it("delegates to adapter.removeWorktree", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await bridge.createBranch("craig/fix-001");
+      await bridge.cleanup("craig/fix-001", "main");
+
+      expect(mock.removeWorktree).toHaveBeenCalledWith("/tmp/craig-mock-wt");
+    });
+
+    it("resets active worktree after cleanup", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      await bridge.createBranch("craig/fix-001");
+      await bridge.cleanup("craig/fix-001", "main");
+
+      // After cleanup, push should throw (no active worktree)
+      await expect(bridge.push("craig/fix-001")).rejects.toThrow(
+        "No active worktree",
+      );
+    });
+
+    it("is safe to call when no worktree is active (no-op)", async () => {
+      const mock = createMockAdapter();
+      const bridge = toAnalyzerGitOps(mock, BASE_BRANCH);
+
+      // Should not throw
+      await bridge.cleanup("craig/fix-001", "main");
+
+      expect(mock.removeWorktree).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/craig/src/git-ops/git-ops.adapter.ts
+++ b/craig/src/git-ops/git-ops.adapter.ts
@@ -1,0 +1,132 @@
+/**
+ * GitOpsAdapter — Worktree-based git operations.
+ *
+ * Implements GitOpsPort using `child_process.execFile` for safe
+ * git command execution. Each operation creates or operates on
+ * an isolated git worktree so parallel branches never collide.
+ *
+ * **Security**: All git commands use `execFile` with argument arrays —
+ * never `exec` with string interpolation — to prevent shell injection.
+ *
+ * @module git-ops
+ * @see [HEXAGONAL] — Adapter implementing the GitOpsPort boundary
+ * @see [CLEAN-CODE] — Small functions, descriptive names, explicit errors
+ * @see [SECURITY] — execFile with arg arrays prevents shell injection
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { randomUUID } from "node:crypto";
+import { writeFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { GitOpsPort } from "./git-ops.port.js";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Git operations adapter using worktree isolation.
+ *
+ * Each `createWorktree` call produces a unique `/tmp/craig-{uuid}` directory
+ * with its own checkout, so multiple fixes can run concurrently without
+ * interfering with each other or the user's working directory.
+ *
+ * [SOLID/SRP] One responsibility: translate GitOpsPort calls → git CLI commands.
+ */
+export class GitOpsAdapter implements GitOpsPort {
+  /** Root directory of the main git repository. */
+  private readonly repoRoot: string;
+
+  constructor(repoRoot: string) {
+    this.repoRoot = repoRoot;
+  }
+
+  /**
+   * Create an isolated worktree on a new branch.
+   *
+   * Runs: `git worktree add /tmp/craig-{uuid} -b {branch} {baseBranch}`
+   *
+   * @returns Absolute path to the new worktree directory.
+   */
+  async createWorktree(
+    branch: string,
+    baseBranch: string,
+  ): Promise<string> {
+    const worktreePath = `/tmp/craig-${randomUUID()}`;
+
+    await execFileAsync(
+      "git",
+      ["worktree", "add", worktreePath, "-b", branch, baseBranch],
+      { cwd: this.repoRoot },
+    );
+
+    return worktreePath;
+  }
+
+  /**
+   * Write files into a worktree, stage, commit, and return the SHA.
+   *
+   * Steps:
+   * 1. Write each file (creating directories as needed)
+   * 2. `git add .`
+   * 3. `git commit -m {message}`
+   * 4. `git rev-parse HEAD` → return SHA
+   *
+   * [CLEAN-CODE] Ordered steps, each clearly documented.
+   */
+  async commitFiles(
+    worktreePath: string,
+    files: Map<string, string>,
+    message: string,
+  ): Promise<string> {
+    // Step 1: Write files
+    for (const [filePath, content] of files) {
+      const fullPath = join(worktreePath, filePath);
+      await mkdir(dirname(fullPath), { recursive: true });
+      await writeFile(fullPath, content, "utf-8");
+    }
+
+    // Step 2: Stage all changes
+    await execFileAsync("git", ["add", "."], { cwd: worktreePath });
+
+    // Step 3: Commit
+    await execFileAsync("git", ["commit", "-m", message], {
+      cwd: worktreePath,
+    });
+
+    // Step 4: Get commit SHA
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: worktreePath,
+    });
+
+    return stdout.trim();
+  }
+
+  /**
+   * Push a branch to origin from a worktree.
+   *
+   * Runs: `git push origin {branch}` in the worktree directory.
+   */
+  async push(worktreePath: string, branch: string): Promise<void> {
+    await execFileAsync("git", ["push", "origin", branch], {
+      cwd: worktreePath,
+    });
+  }
+
+  /**
+   * Remove a worktree and its directory.
+   *
+   * Runs: `git worktree remove {path} --force`
+   * Uses --force to remove even if there are uncommitted changes.
+   */
+  async removeWorktree(worktreePath: string): Promise<void> {
+    await execFileAsync(
+      "git",
+      ["worktree", "remove", worktreePath, "--force"],
+      { cwd: this.repoRoot },
+    );
+  }
+}

--- a/craig/src/git-ops/git-ops.port.ts
+++ b/craig/src/git-ops/git-ops.port.ts
@@ -1,0 +1,73 @@
+/**
+ * Port for local git operations using worktree isolation.
+ *
+ * Worktrees provide isolated checkouts — each branch gets its own
+ * directory, so parallel operations (e.g., multiple auto-develop fixes)
+ * cannot interfere with each other or with the user's working directory.
+ *
+ * @module git-ops
+ * @see [HEXAGONAL] — Port defining the boundary for local git operations
+ * @see [SOLID/DIP] — Consumers depend on this abstraction, not child_process
+ */
+
+// ---------------------------------------------------------------------------
+// GitOpsPort — Worktree-based local git operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Port for local git operations using worktree isolation.
+ *
+ * Each operation is explicit about which worktree it targets,
+ * making the API safe for concurrent use across multiple branches.
+ *
+ * **Security**: Implementations MUST use `execFile` (not `exec`)
+ * with argument arrays to prevent shell injection.
+ */
+export interface GitOpsPort {
+  /**
+   * Create an isolated git worktree on a new branch.
+   *
+   * Equivalent to: `git worktree add /tmp/craig-{uuid} -b {branch} {baseBranch}`
+   *
+   * @param branch - New branch name to create (e.g., "craig/fix-finding-001")
+   * @param baseBranch - Base branch to fork from (e.g., "main")
+   * @returns Absolute path to the worktree directory
+   */
+  createWorktree(branch: string, baseBranch: string): Promise<string>;
+
+  /**
+   * Write files, stage all changes, and commit in a worktree.
+   *
+   * Writes each entry in `files` to the worktree, runs `git add .`,
+   * then `git commit -m {message}`.
+   *
+   * @param worktreePath - Absolute path to the worktree
+   * @param files - Map of relative file paths → file contents
+   * @param message - Commit message
+   * @returns The commit SHA
+   */
+  commitFiles(
+    worktreePath: string,
+    files: Map<string, string>,
+    message: string,
+  ): Promise<string>;
+
+  /**
+   * Push a branch to the remote origin from a worktree.
+   *
+   * Equivalent to: `git push origin {branch}` (run inside the worktree).
+   *
+   * @param worktreePath - Absolute path to the worktree
+   * @param branch - Branch name to push
+   */
+  push(worktreePath: string, branch: string): Promise<void>;
+
+  /**
+   * Remove a git worktree and clean up its directory.
+   *
+   * Equivalent to: `git worktree remove {worktreePath} --force`
+   *
+   * @param worktreePath - Absolute path to the worktree to remove
+   */
+  removeWorktree(worktreePath: string): Promise<void>;
+}

--- a/craig/src/git-ops/index.ts
+++ b/craig/src/git-ops/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Git-Ops module — barrel exports.
+ *
+ * Exports the worktree-based GitOpsPort, its adapter, and a bridge
+ * function that adapts the worktree API to the stateful GitOpsPort
+ * consumed by auto-fix and auto-develop analyzers.
+ *
+ * @module git-ops
+ * @see [HEXAGONAL] — Module boundary with clean public API
+ */
+
+export type { GitOpsPort } from "./git-ops.port.js";
+export { GitOpsAdapter } from "./git-ops.adapter.js";
+
+// ---------------------------------------------------------------------------
+// Bridge: worktree GitOpsPort → auto-fix/auto-develop GitOpsPort
+// ---------------------------------------------------------------------------
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { GitOpsPort } from "./git-ops.port.js";
+import type { GitOpsPort as AnalyzerGitOpsPort } from "../analyzers/auto-fix/auto-fix.ports.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Bridge a worktree-based GitOpsPort into the stateful GitOpsPort
+ * interface expected by auto-develop (and auto-fix) analyzers.
+ *
+ * The auto-develop analyzer calls methods like `createBranch(name)` then
+ * later `hasChanges()` / `commitAll(msg)` — a stateful API where the
+ * "current branch" is implicit. Worktree operations are explicit about
+ * which directory they target.
+ *
+ * This bridge maintains the active worktree path as internal state,
+ * translating the stateful calls into explicit worktree operations.
+ *
+ * @param adapter - Worktree-based GitOpsPort implementation
+ * @param baseBranch - Default branch to fork from (e.g., "main")
+ * @returns An AnalyzerGitOpsPort compatible with AutoDevelopDeps.gitOps
+ *
+ * [HEXAGONAL] Adapter pattern — translates between two port interfaces
+ * [CLEAN-CODE] State is encapsulated; each method validates preconditions
+ */
+export function toAnalyzerGitOps(
+  adapter: GitOpsPort,
+  baseBranch: string,
+): AnalyzerGitOpsPort {
+  let activeWorktree: string | null = null;
+
+  return {
+    async createBranch(name: string): Promise<void> {
+      activeWorktree = await adapter.createWorktree(name, baseBranch);
+    },
+
+    async hasChanges(): Promise<boolean> {
+      if (!activeWorktree) return false;
+
+      const { stdout } = await execFileAsync(
+        "git",
+        ["status", "--porcelain"],
+        { cwd: activeWorktree },
+      );
+
+      return stdout.trim().length > 0;
+    },
+
+    async getChangedFiles(): Promise<string[]> {
+      if (!activeWorktree) return [];
+
+      const { stdout } = await execFileAsync(
+        "git",
+        ["status", "--porcelain"],
+        { cwd: activeWorktree },
+      );
+
+      return stdout
+        .trim()
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .map((line) => line.substring(3)); // strip status prefix "?? " / " M " etc.
+    },
+
+    async commitAll(message: string): Promise<string> {
+      if (!activeWorktree) {
+        throw new Error(
+          "No active worktree — call createBranch before commitAll",
+        );
+      }
+
+      await execFileAsync("git", ["add", "-A"], { cwd: activeWorktree });
+      await execFileAsync("git", ["commit", "-m", message], {
+        cwd: activeWorktree,
+      });
+      const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+        cwd: activeWorktree,
+      });
+
+      return stdout.trim();
+    },
+
+    async push(branchName: string): Promise<void> {
+      if (!activeWorktree) {
+        throw new Error(
+          "No active worktree — call createBranch before push",
+        );
+      }
+
+      await adapter.push(activeWorktree, branchName);
+    },
+
+    async cleanup(_branchName: string, _defaultBranch: string): Promise<void> {
+      if (!activeWorktree) return;
+
+      await adapter.removeWorktree(activeWorktree);
+      activeWorktree = null;
+    },
+  };
+}

--- a/craig/src/index.ts
+++ b/craig/src/index.ts
@@ -37,6 +37,8 @@ import { createPlatformAuditAnalyzer } from "./analyzers/platform-audit/index.js
 import { createDeliveryAuditAnalyzer } from "./analyzers/delivery-audit/index.js";
 import { createResultParser } from "./result-parser/index.js";
 import { GitHubAdapter } from "./github/index.js";
+import { createAutoDevelopAnalyzer } from "./analyzers/auto-develop/index.js";
+import { GitOpsAdapter, toAnalyzerGitOps } from "./git-ops/index.js";
 
 /**
  * Bootstrap and start the Craig MCP server.
@@ -137,8 +139,11 @@ async function main(): Promise<void> {
         }));
       }
       if ((cfg.capabilities as Record<string, unknown>).auto_develop) {
-        // Auto-develop needs GitOpsPort adapter (not yet built) — skip for now
-        console.error("[Craig] auto_develop capability requires GitOpsPort — skipping (follow-up ticket)");
+        const gitOpsAdapter = new GitOpsAdapter(process.cwd());
+        const analyzerGitOps = toAnalyzerGitOps(gitOpsAdapter, cfg.branch);
+        analyzers.push(createAutoDevelopAnalyzer({
+          copilot, git: github, state, config, gitOps: analyzerGitOps,
+        }));
       }
       if ((cfg.capabilities as Record<string, unknown>).platform_audit) {
         analyzers.push(createPlatformAuditAnalyzer({


### PR DESCRIPTION
## Summary

Implements the **GitOpsPort** adapter for worktree-based git operations and wires it into the `auto_develop` analyzer, removing the skip message.

### What was implemented

| File | Change | Tests |
|------|--------|-------|
| `craig/src/git-ops/git-ops.port.ts` | New `GitOpsPort` interface — worktree-based operations | — |
| `craig/src/git-ops/git-ops.adapter.ts` | `GitOpsAdapter` class using `child_process.execFile` | 14 tests |
| `craig/src/git-ops/index.ts` | Barrel exports + `toAnalyzerGitOps` bridge function | 10 tests |
| `craig/src/git-ops/__tests__/git-ops.adapter.test.ts` | 24 unit tests | — |
| `craig/src/index.ts` | Wire `GitOpsAdapter` → `auto_develop` analyzer | — |

### Architecture Decisions

| # | Decision | Rationale | Reversible? |
|---|----------|-----------|-------------|
| 1 | New `GitOpsPort` uses worktree-level API (explicit `worktreePath` per call) | Worktrees provide isolation for parallel branch operations — safer than `git checkout` `[HEXAGONAL]` | Yes |
| 2 | `toAnalyzerGitOps()` bridge adapts worktree port → stateful `auto-fix.GitOpsPort` | `AutoDevelopDeps.gitOps` expects the existing stateful interface; bridge translates between the two without modifying auto-develop `[SOLID/OCP]` | Yes |
| 3 | All git commands use `execFile` with argument arrays (never `exec`) | Prevents shell injection — user-controlled branch names cannot escape to shell `[SECURITY]` | No — this is a security requirement |
| 4 | Worktree paths use `/tmp/craig-{uuid}` | Unique paths prevent collisions between parallel operations | Yes |

### Tests
- ✅ 24 unit tests written (24/24 passing)
- ✅ Full suite: 1032 tests, 39 files — all passing
- ✅ TypeScript strict mode: zero errors

### Security
- [x] No hardcoded secrets
- [x] `execFile` with argument arrays (no shell injection)
- [x] No sensitive data in logs
- [x] Error responses don't leak internals
