### PR TITLE
Formal Specification as first SDLC artifact (Spec Kit-compatible) — closes #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The Guardians are not invoked manually — the default Copilot agent enforces th
 💡 Idea
   │
   ├─ No ticket? → 🎯 PO Guardian creates specification (auto)
+  │                    └─ For multi-component / cross-Guardian work,
+  │                       PO produces a Spec Kit-compatible Formal Spec
+  │                       at specs/{feature}/spec.md (per-request judgment)
   │
   ▼
 🎯 Specification exists
@@ -413,6 +416,8 @@ Every finding, requirement, and recommendation produced by a Guardian cites its 
 │       ├── extension.mjs                ← SDK wiring shell (thin)
 │       ├── uat-state-machine.mjs        ← Pure state-machine logic (testable)
 │       └── uat-state-machine.test.mjs   ← Zero-dep tests (node --test)
+├── templates/                           ← Reusable artifact templates
+│   └── feature-spec.template.md         ← Spec Kit-compatible Formal Spec template
 ├── reports/                             ← Operator output (created at runtime by Operator)
 │   ├── weekly-recap-2026-04-05-170030.md
 │   └── grafana-dashboard-2026-04-05-083015.png

--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ The Guardians are not invoked manually — the default Copilot agent enforces th
   ├─── 🚀 Delivery Guardian ────────┘  if deployment config changed
   │
   ▼
-✅ PR → Merge → Deploy
+✅ PR → Merge
+  │
+  │ ── Post-Merge Archive Gate (auto-triggered) ──
+  │
+  └─── 📚 Operator (background)
+        └─ Curates archive/{feature_slug}.md from spec + tickets + PR + Guardian reports
+  │
+  ▼
+🚢 Deploy
 
 ── Operational Track (parallel, non-blocking) ──
 
@@ -137,14 +145,15 @@ The Guardians are not invoked manually — the default Copilot agent enforces th
                                         └─ Results → ~/.copilot/reports/
 ```
 
-**Five quality gates, enforced automatically:**
+**Six quality gates, enforced automatically:**
 
 | Gate | When | What happens |
 |------|------|-------------|
-| **Pre-Implementation** | User asks to implement without a ticket | PO Guardian invoked to create specification first |
+| **Pre-Implementation** | User asks to implement without a ticket | PO Guardian invoked to create specification first; per-request judgment on whether a Spec Kit-compatible Formal Spec is also produced at `specs/{feature}/spec.md` |
 | **UAT Checkpoint** | Developer Guardian completes | User offered a chance to test the worktree + pair-fix with Developer Guardian (auto-entered in autopilot mode). After 3 pair-fix iterations the orchestrator recommends moving to the review gate. |
-| **Post-Implementation** | UAT done or skipped | QA + Security + Privacy + Code Review invoked in parallel automatically |
+| **Post-Implementation** | UAT done or skipped | QA + Security + Privacy + Code Review invoked in parallel automatically (Code Review Domain 8 enforces Parent Spec linkage and spec drift) |
 | **Pre-Merge** | All Guardian reviews pass + CI checks pass | Default agent presents combined results; user confirms merge approval |
+| **Post-Merge Archive** | Feature ticket merged | Operator dispatched to curate `archive/{feature_slug}.md` from spec + tickets + PR diff + Guardian session reports |
 | **Pre-Deployment** | User asks to deploy | Platform + Delivery Guardians verify infrastructure and operations readiness |
 
 The user never needs to remember which Guardian to invoke. The workflow enforces it.

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ See **[PREREQUISITES.md](PREREQUISITES.md)** for the complete setup guide — co
 
 ### Installation
 
+**macOS / Linux:**
+
 ```bash
 unzip sdlc-guardian-agents.zip -d ~/.copilot/
 ```
@@ -316,6 +318,16 @@ git clone https://github.com/vbomfim/sdlc-guardian-agents.git
 cd sdlc-guardian-agents
 ./package.sh --install
 ```
+
+**Windows (PowerShell):**
+
+```powershell
+git clone https://github.com/vbomfim/sdlc-guardian-agents.git
+cd sdlc-guardian-agents
+.\package.ps1 -Install
+```
+
+The PowerShell script (`package.ps1`) is the Windows equivalent of `package.sh` — same install layout under `%USERPROFILE%\.copilot\`, same Guardian roster, same `-Install`, `-Uninstall`, `-Doctor` operations.
 
 ### Usage
 

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -96,8 +96,9 @@ The PO Guardian will:
 - **Ask you questions** — don't expect it to assume. It asks about auth, deployment, accessibility, data sensitivity, etc.
 - **Classify your app type** — frontend, API, full-stack, CLI, etc. This determines which quality concerns apply.
 - **Check project documentation** — if README or ARCHITECTURE.md is missing, it offers to create them with you.
+- **Decide whether a Formal Spec is warranted** — for multi-component, cross-Guardian, or architecturally significant work, the PO produces a Spec Kit-compatible spec at `specs/{feature}/spec.md` in your project repo. For trivial work it skips the spec and notes the reason in the ticket. Either way, every ticket carries a `Parent Spec:` field so the decision is visible.
 - **Decompose large requests** — breaks big features into modules, then components, then tickets. You approve the decomposition before it details anything.
-- **Create an issue** — the spec lives in the issue tracker (GitHub Issues, Azure DevOps Work Items, etc.), not in a markdown file.
+- **Create an issue** — the spec lives in the issue tracker (GitHub Issues, Azure DevOps Work Items, etc.). The Formal Spec, when produced, lives at `specs/{feature}/spec.md` in your repo and is linked bidirectionally with the issue.
 
 **Example interaction:**
 ```

--- a/package.ps1
+++ b/package.ps1
@@ -64,7 +64,14 @@ $ErrorActionPreference = 'Stop'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $SrcDir    = Join-Path $ScriptDir 'src'
 $DistDir   = Join-Path $ScriptDir 'dist'
-$TargetDir = Join-Path $env:USERPROFILE '.copilot'
+
+# Cross-platform user profile directory:
+#   Windows → %USERPROFILE% (e.g. C:\Users\vbomfim)
+#   macOS / Linux → $HOME (e.g. /Users/vbomfim)
+# [Environment]::GetFolderPath('UserProfile') returns the correct location on
+# both platforms, which keeps the install layout identical to package.sh.
+$UserHome  = [Environment]::GetFolderPath('UserProfile')
+$TargetDir = Join-Path $UserHome '.copilot'
 
 # ────────────────────────────────────────────────────────────────────────────
 # Guardian roster — single source of truth (must match package.sh)
@@ -119,7 +126,8 @@ function Copy-DirContents {
         throw "Source directory not found: $From"
     }
     New-DirIfMissing -Path $To
-    Copy-Item -LiteralPath (Join-Path $From '*') -Destination $To -Recurse -Force
+    # -Path (not -LiteralPath) so the wildcard is expanded
+    Copy-Item -Path (Join-Path $From '*') -Destination $To -Recurse -Force
 }
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -137,7 +145,7 @@ function Invoke-Package {
     }
 
     # Build a staging dir that mirrors src but excludes hidden files and *.test.* files
-    $staging = Join-Path $env:TEMP "sdlc-guardian-stage-$(Get-Random)"
+    $staging = Join-Path ([System.IO.Path]::GetTempPath()) "sdlc-guardian-stage-$(Get-Random)"
     try {
         New-DirIfMissing -Path $staging
 
@@ -164,7 +172,7 @@ function Invoke-Package {
     Write-Ok "Package created: dist\sdlc-guardian-agents.zip ($size)"
     Write-Host ''
     Write-Host '  To install:'
-    Write-Info '    Expand-Archive dist\sdlc-guardian-agents.zip -DestinationPath $env:USERPROFILE\.copilot\'
+    Write-Info '    Expand-Archive dist\sdlc-guardian-agents.zip -DestinationPath (Join-Path ([Environment]::GetFolderPath(''UserProfile'')) ''.copilot'')'
     Write-Info '    .\package.ps1 -Install   (recommended)'
 }
 

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,575 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    SDLC Guardian Agents — Package & Deploy (Windows / PowerShell)
+
+.DESCRIPTION
+    Windows equivalent of package.sh. Functionally identical:
+    - Builds the distributable zip (dist\sdlc-guardian-agents.zip)
+    - Installs to %USERPROFILE%\.copilot\
+    - Uninstalls from %USERPROFILE%\.copilot\ (preserving user side-notes)
+    - Runs the doctor preflight to verify tools and Guardian files
+
+    The Copilot CLI on Windows reads from %USERPROFILE%\.copilot\, the same
+    relative location as ~/.copilot on macOS/Linux, so the installed layout
+    is identical.
+
+.PARAMETER Install
+    Build zip AND install to %USERPROFILE%\.copilot\
+
+.PARAMETER Uninstall
+    Remove SDLC Guardian Agents files from %USERPROFILE%\.copilot\
+    (side-notes *.notes.md files are preserved — they are user data)
+
+.PARAMETER Doctor
+    Verify all prerequisites are installed (Git, gh, Copilot CLI, optional
+    Guardian tools) and that Guardian files have been deployed.
+
+.EXAMPLE
+    .\package.ps1
+    Build zip only.
+
+.EXAMPLE
+    .\package.ps1 -Install
+    Build zip and install to %USERPROFILE%\.copilot\
+
+.EXAMPLE
+    .\package.ps1 -Uninstall
+
+.EXAMPLE
+    .\package.ps1 -Doctor
+
+.NOTES
+    Mirror of package.sh. Keep changes in sync between the two scripts.
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'Package')]
+param(
+    [Parameter(ParameterSetName = 'Install')]
+    [switch]$Install,
+
+    [Parameter(ParameterSetName = 'Uninstall')]
+    [switch]$Uninstall,
+
+    [Parameter(ParameterSetName = 'Doctor')]
+    [switch]$Doctor
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ────────────────────────────────────────────────────────────────────────────
+# Paths
+# ────────────────────────────────────────────────────────────────────────────
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SrcDir    = Join-Path $ScriptDir 'src'
+$DistDir   = Join-Path $ScriptDir 'dist'
+$TargetDir = Join-Path $env:USERPROFILE '.copilot'
+
+# ────────────────────────────────────────────────────────────────────────────
+# Guardian roster — single source of truth (must match package.sh)
+# ────────────────────────────────────────────────────────────────────────────
+
+$Guardians = @(
+    'security-guardian',
+    'code-review-guardian',
+    'po-guardian',
+    'dev-guardian',
+    'qa-guardian',
+    'platform-guardian',
+    'delivery-guardian',
+    'privacy-guardian'
+)
+
+# ────────────────────────────────────────────────────────────────────────────
+# Helpers — colored output
+# ────────────────────────────────────────────────────────────────────────────
+
+function Write-Ok      { param([string]$Msg) Write-Host "✔  $Msg" -ForegroundColor Green }
+function Write-Bad     { param([string]$Msg) Write-Host "✘  $Msg" -ForegroundColor Red }
+function Write-Warn    { param([string]$Msg) Write-Host "⚠  $Msg" -ForegroundColor Yellow }
+function Write-Info    { param([string]$Msg) Write-Host $Msg -ForegroundColor Cyan }
+function Write-Section { param([string]$Msg) Write-Host ''; Write-Host $Msg -ForegroundColor White }
+function Write-Bold    { param([string]$Msg) Write-Host $Msg -ForegroundColor White }
+
+function New-DirIfMissing {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Copy-FileSafe {
+    param(
+        [Parameter(Mandatory)] [string]$From,
+        [Parameter(Mandatory)] [string]$To
+    )
+    if (-not (Test-Path -LiteralPath $From)) {
+        throw "Source file not found: $From"
+    }
+    Copy-Item -LiteralPath $From -Destination $To -Force
+}
+
+function Copy-DirContents {
+    param(
+        [Parameter(Mandatory)] [string]$From,
+        [Parameter(Mandatory)] [string]$To
+    )
+    if (-not (Test-Path -LiteralPath $From)) {
+        throw "Source directory not found: $From"
+    }
+    New-DirIfMissing -Path $To
+    Copy-Item -LiteralPath (Join-Path $From '*') -Destination $To -Recurse -Force
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# package — build zip
+# ────────────────────────────────────────────────────────────────────────────
+
+function Invoke-Package {
+    Write-Host ''
+    Write-Info '📦 Packaging SDLC Guardian Agents...'
+
+    New-DirIfMissing -Path $DistDir
+    $zipPath = Join-Path $DistDir 'sdlc-guardian-agents.zip'
+    if (Test-Path -LiteralPath $zipPath) {
+        Remove-Item -LiteralPath $zipPath -Force
+    }
+
+    # Build a staging dir that mirrors src but excludes hidden files and *.test.* files
+    $staging = Join-Path $env:TEMP "sdlc-guardian-stage-$(Get-Random)"
+    try {
+        New-DirIfMissing -Path $staging
+
+        Get-ChildItem -LiteralPath $SrcDir -Recurse -File | Where-Object {
+            $_.Name -notlike '.*' -and $_.Name -notmatch '\.test\.'
+        } | ForEach-Object {
+            $relative = $_.FullName.Substring($SrcDir.Length).TrimStart('\', '/')
+            $destPath = Join-Path $staging $relative
+            $destDir  = Split-Path -Parent $destPath
+            New-DirIfMissing -Path $destDir
+            Copy-Item -LiteralPath $_.FullName -Destination $destPath -Force
+        }
+
+        Compress-Archive -Path (Join-Path $staging '*') -DestinationPath $zipPath -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $staging) {
+            Remove-Item -LiteralPath $staging -Recurse -Force
+        }
+    }
+
+    $size = '{0:N0} KB' -f ((Get-Item -LiteralPath $zipPath).Length / 1KB)
+    Write-Host ''
+    Write-Ok "Package created: dist\sdlc-guardian-agents.zip ($size)"
+    Write-Host ''
+    Write-Host '  To install:'
+    Write-Info '    Expand-Archive dist\sdlc-guardian-agents.zip -DestinationPath $env:USERPROFILE\.copilot\'
+    Write-Info '    .\package.ps1 -Install   (recommended)'
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# install — copy files into ~/.copilot/
+# ────────────────────────────────────────────────────────────────────────────
+
+function Invoke-Install {
+    Write-Host ''
+    Write-Info "🛡️  Installing Guardians to $TargetDir\..."
+    Write-Host ''
+
+    # Ensure target dirs exist
+    New-DirIfMissing (Join-Path $TargetDir 'skills\security-guardian')
+    New-DirIfMissing (Join-Path $TargetDir 'skills\code-review-guardian')
+    New-DirIfMissing (Join-Path $TargetDir 'skills\platform-guardian')
+    New-DirIfMissing (Join-Path $TargetDir 'skills\privacy-guardian')
+    New-DirIfMissing (Join-Path $TargetDir 'agents')
+    New-DirIfMissing (Join-Path $TargetDir 'instructions')
+    New-DirIfMissing (Join-Path $TargetDir 'templates')
+
+    # ── Install agents ──
+    foreach ($g in $Guardians) {
+        Copy-FileSafe -From (Join-Path $SrcDir "agents\$g.agent.md") -To (Join-Path $TargetDir 'agents')
+    }
+
+    # ── Install instructions ──
+    foreach ($g in $Guardians) {
+        Copy-FileSafe -From (Join-Path $SrcDir "instructions\$g.instructions.md") -To (Join-Path $TargetDir 'instructions')
+    }
+    Copy-FileSafe -From (Join-Path $SrcDir 'instructions\sdlc-workflow.instructions.md') -To (Join-Path $TargetDir 'instructions')
+
+    # ── Install Operator (not a Guardian — separate naming convention) ──
+    Copy-FileSafe -From (Join-Path $SrcDir 'agents\operator.agent.md') -To (Join-Path $TargetDir 'agents')
+    Copy-FileSafe -From (Join-Path $SrcDir 'instructions\operator.instructions.md') -To (Join-Path $TargetDir 'instructions')
+
+    # ── Install Craig instructions ──
+    Copy-FileSafe -From (Join-Path $SrcDir 'instructions\craig.instructions.md') -To (Join-Path $TargetDir 'instructions')
+
+    # ── Install templates (Spec Kit-compatible Formal Spec, etc.) ──
+    Copy-FileSafe -From (Join-Path $SrcDir 'templates\feature-spec.template.md') -To (Join-Path $TargetDir 'templates')
+
+    # ── Install skills (tool definitions only — no scripts) ──
+    New-DirIfMissing (Join-Path $TargetDir 'skills\playwright-mcp')
+    Copy-DirContents -From (Join-Path $SrcDir 'skills\security-guardian')    -To (Join-Path $TargetDir 'skills\security-guardian')
+    Copy-DirContents -From (Join-Path $SrcDir 'skills\code-review-guardian') -To (Join-Path $TargetDir 'skills\code-review-guardian')
+    Copy-DirContents -From (Join-Path $SrcDir 'skills\platform-guardian')    -To (Join-Path $TargetDir 'skills\platform-guardian')
+    Copy-DirContents -From (Join-Path $SrcDir 'skills\privacy-guardian')     -To (Join-Path $TargetDir 'skills\privacy-guardian')
+    Copy-DirContents -From (Join-Path $SrcDir 'skills\playwright-mcp')       -To (Join-Path $TargetDir 'skills\playwright-mcp')
+
+    # ── Install extensions (runtime modules only — no test files) ──
+    New-DirIfMissing (Join-Path $TargetDir 'extensions\sdlc-guardian')
+    Copy-FileSafe -From (Join-Path $SrcDir 'extensions\sdlc-guardian\extension.mjs')         -To (Join-Path $TargetDir 'extensions\sdlc-guardian')
+    Copy-FileSafe -From (Join-Path $SrcDir 'extensions\sdlc-guardian\uat-state-machine.mjs') -To (Join-Path $TargetDir 'extensions\sdlc-guardian')
+
+    New-DirIfMissing (Join-Path $TargetDir 'extensions\craig')
+    Copy-FileSafe -From (Join-Path $SrcDir 'extensions\craig\extension.mjs')      -To (Join-Path $TargetDir 'extensions\craig')
+    Copy-FileSafe -From (Join-Path $SrcDir 'extensions\craig\craig-scheduler.mjs') -To (Join-Path $TargetDir 'extensions\craig')
+    Copy-FileSafe -From (Join-Path $SrcDir 'extensions\craig\craig-config.mjs')   -To (Join-Path $TargetDir 'extensions\craig')
+
+    # ── Seed side-notes files (never overwrite existing — user data) ──
+    $notesCreated = 0
+    $notesExisted = 0
+    foreach ($g in $Guardians) {
+        if ($g -notmatch '^[a-z-]+$') { continue }
+        $notesFile = Join-Path $TargetDir "instructions\$g.notes.md"
+        if (-not (Test-Path -LiteralPath $notesFile)) {
+            $body = @"
+# $g — Advisory Notes
+
+<!-- Learned patterns from past reviews. Guardians read this file at startup. -->
+<!-- Add notes as markdown bullets. Keep to ~20 items; prune when exceeded. -->
+"@
+            # Use WriteAllText so we get UTF-8 without BOM (matches package.sh output)
+            [System.IO.File]::WriteAllText($notesFile, $body, [System.Text.UTF8Encoding]::new($false))
+            $notesCreated++
+        } else {
+            $notesExisted++
+        }
+    }
+
+    # ── Print summary in package.sh order ──
+    Write-Bold 'Security Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/security-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/security-guardian.instructions.md'
+    Write-Ok 'Skill:        ~/.copilot/skills/security-guardian/'
+    Write-Host ''
+    Write-Bold 'Code Review Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/code-review-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/code-review-guardian.instructions.md'
+    Write-Ok 'Skill:        ~/.copilot/skills/code-review-guardian/'
+    Write-Host ''
+    Write-Bold 'Product Owner Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/po-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/po-guardian.instructions.md'
+    Write-Host ''
+    Write-Bold 'Developer Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/dev-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/dev-guardian.instructions.md'
+    Write-Host ''
+    Write-Bold 'QA Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/qa-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/qa-guardian.instructions.md'
+    Write-Host ''
+    Write-Bold 'Platform Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/platform-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/platform-guardian.instructions.md'
+    Write-Ok 'Skill:        ~/.copilot/skills/platform-guardian/'
+    Write-Host ''
+    Write-Bold 'Delivery Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/delivery-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/delivery-guardian.instructions.md'
+    Write-Host ''
+    Write-Bold 'Privacy Guardian:'
+    Write-Ok 'Agent:        ~/.copilot/agents/privacy-guardian.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/privacy-guardian.instructions.md'
+    Write-Ok 'Skill:        ~/.copilot/skills/privacy-guardian/'
+    Write-Host ''
+    Write-Bold 'Operator (task runner):'
+    Write-Ok 'Agent:        ~/.copilot/agents/operator.agent.md'
+    Write-Ok 'Instructions: ~/.copilot/instructions/operator.instructions.md'
+    Write-Ok 'Skill:        ~/.copilot/skills/playwright-mcp/'
+    Write-Host ''
+    Write-Bold 'Craig (scheduled tasks):'
+    Write-Ok 'Instructions: ~/.copilot/instructions/craig.instructions.md'
+    Write-Ok 'Extension:    ~/.copilot/extensions/craig/extension.mjs'
+    Write-Ok 'Scheduler:    ~/.copilot/extensions/craig/craig-scheduler.mjs'
+    Write-Ok 'Config loader: ~/.copilot/extensions/craig/craig-config.mjs'
+    Write-Host ''
+    Write-Bold 'SDLC Guardian Extension:'
+    Write-Ok 'Extension:    ~/.copilot/extensions/sdlc-guardian/extension.mjs'
+    Write-Ok 'State machine: ~/.copilot/extensions/sdlc-guardian/uat-state-machine.mjs'
+    Write-Host ''
+    Write-Bold 'Templates:'
+    Write-Ok 'Feature Spec: ~/.copilot/templates/feature-spec.template.md (Spec Kit-compatible)'
+    Write-Host ''
+    Write-Bold 'Side-Notes (advisory):'
+    Write-Ok ('Notes: {0} created, {1} preserved' -f $notesCreated, $notesExisted)
+    Write-Host ''
+    Write-Bold "You're set! Open Copilot CLI and:"
+    Write-Host '  • Global instructions are already active' -ForegroundColor Green
+    Write-Host '  • Use /agent to pick any Guardian (Security, Code Review, PO, …)'
+    Write-Host '  • Say "set up security" to install scanning tools'
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# uninstall — remove Guardian files (preserve side-notes)
+# ────────────────────────────────────────────────────────────────────────────
+
+function Remove-IfExists {
+    param([string]$Path, [string]$Description)
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+        Write-Ok "Removed $Description"
+    }
+}
+
+function Invoke-Uninstall {
+    Write-Host ''
+    Write-Host '🗑️  Uninstalling Guardians...' -ForegroundColor Yellow
+    Write-Host ''
+
+    foreach ($g in $Guardians) {
+        Remove-IfExists -Path (Join-Path $TargetDir "skills\$g")                  -Description "~/.copilot/skills/$g/"
+        Remove-IfExists -Path (Join-Path $TargetDir "agents\$g.agent.md")          -Description "~/.copilot/agents/$g.agent.md"
+        Remove-IfExists -Path (Join-Path $TargetDir "instructions\$g.instructions.md") -Description "~/.copilot/instructions/$g.instructions.md"
+    }
+
+    Remove-IfExists -Path (Join-Path $TargetDir 'instructions\sdlc-workflow.instructions.md') -Description '~/.copilot/instructions/sdlc-workflow.instructions.md'
+    Remove-IfExists -Path (Join-Path $TargetDir 'agents\operator.agent.md')                   -Description '~/.copilot/agents/operator.agent.md'
+    Remove-IfExists -Path (Join-Path $TargetDir 'instructions\operator.instructions.md')      -Description '~/.copilot/instructions/operator.instructions.md'
+    Remove-IfExists -Path (Join-Path $TargetDir 'extensions\sdlc-guardian')                   -Description '~/.copilot/extensions/sdlc-guardian/'
+    Remove-IfExists -Path (Join-Path $TargetDir 'extensions\craig')                           -Description '~/.copilot/extensions/craig/'
+
+    # ── Remove templates ──
+    Remove-IfExists -Path (Join-Path $TargetDir 'templates\feature-spec.template.md') -Description '~/.copilot/templates/feature-spec.template.md'
+    $templatesDir = Join-Path $TargetDir 'templates'
+    if ((Test-Path -LiteralPath $templatesDir) -and (-not (Get-ChildItem -LiteralPath $templatesDir))) {
+        Remove-Item -LiteralPath $templatesDir -Force
+        Write-Ok 'Removed empty ~/.copilot/templates/'
+    }
+
+    Write-Host ''
+    Write-Host 'Done.' -ForegroundColor Green
+    Write-Host 'Repo-level files (.github/) are untouched — remove per-repo if needed.'
+    Write-Host 'Side-notes files (~/.copilot/instructions/*.notes.md) are preserved — they contain user data.' -ForegroundColor DarkGray
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# doctor — verify prerequisites and installed Guardian files
+# ────────────────────────────────────────────────────────────────────────────
+
+# Doctor counters (script-scoped so the check helpers can update them)
+$script:DoctorTotal           = 0
+$script:DoctorAvailable       = 0
+$script:DoctorOptionalMissing = 0
+$script:DoctorCoreMissing     = 0
+$script:DoctorFileTotal       = 0
+$script:DoctorFileOk          = 0
+$script:DoctorFileMissing     = 0
+
+function Test-Tool {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [string]$Command,
+        [string]$VersionFlag = '',
+        [Parameter(Mandatory)] [string]$Guardian,
+        [string]$Hint = '',
+        [switch]$Core
+    )
+    $script:DoctorTotal++
+
+    $cmdInfo = Get-Command $Command -ErrorAction SilentlyContinue
+    if ($cmdInfo) {
+        $version = ''
+        if ($VersionFlag) {
+            try {
+                $output = & $Command $VersionFlag.Split(' ') 2>&1 | Out-String
+                $match = [regex]::Match($output, '\d+\.\d+(\.\d+)*')
+                if ($match.Success) { $version = $match.Value }
+            } catch {
+                # ignore — version detection is best-effort
+            }
+        }
+        if ($version) {
+            Write-Host "  ✅ $Name " -NoNewline -ForegroundColor Green
+            Write-Host "($version)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "  ✅ $Name" -ForegroundColor Green
+        }
+        $script:DoctorAvailable++
+        return
+    }
+
+    if ($Core) {
+        Write-Host "  ❌ $Name " -NoNewline -ForegroundColor Red
+        Write-Host "— Used by: $Guardian" -ForegroundColor DarkGray
+        $script:DoctorCoreMissing++
+    } else {
+        Write-Host "  ⚠  $Name " -NoNewline -ForegroundColor Yellow
+        Write-Host "— Used by: $Guardian" -ForegroundColor DarkGray
+        $script:DoctorOptionalMissing++
+    }
+    if ($Hint) {
+        Write-Host "      Install: $Hint" -ForegroundColor DarkGray
+    }
+}
+
+function Test-Artifact {
+    param(
+        [Parameter(Mandatory)] [string]$RelativePath,
+        [Parameter(Mandatory)] [string]$Description
+    )
+    $script:DoctorFileTotal++
+    $fullPath = Join-Path $TargetDir $RelativePath
+
+    if (Test-Path -LiteralPath $fullPath) {
+        Write-Host "  ✅ $Description" -ForegroundColor Green
+        $script:DoctorFileOk++
+    } else {
+        Write-Host "  ⚠  $Description " -NoNewline -ForegroundColor Yellow
+        Write-Host "— ~/.copilot/$RelativePath" -ForegroundColor DarkGray
+        $script:DoctorFileMissing++
+    }
+}
+
+function Doctor-CheckTools {
+    Write-Section 'Core Requirements'
+    Test-Tool -Name 'Git'         -Command 'git'     -VersionFlag '--version' -Guardian 'All Guardians'             -Hint 'see PREREQUISITES.md' -Core
+    Test-Tool -Name 'GitHub CLI'  -Command 'gh'      -VersionFlag '--version' -Guardian 'PO Guardian, Default Agent' -Hint 'see PREREQUISITES.md' -Core
+    Test-Tool -Name 'Copilot CLI' -Command 'copilot' -VersionFlag '--version' -Guardian 'All Guardians'             -Hint 'see PREREQUISITES.md' -Core
+
+    Write-Section 'Security Guardian Tools'
+    Test-Tool -Name 'Semgrep'  -Command 'semgrep'  -VersionFlag '--version' -Guardian 'Security Guardian, Privacy Guardian' -Hint 'pip install semgrep (see PREREQUISITES.md)'
+    Test-Tool -Name 'Gitleaks' -Command 'gitleaks' -VersionFlag 'version'   -Guardian 'Security Guardian, Privacy Guardian' -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'Trivy'    -Command 'trivy'    -VersionFlag '--version' -Guardian 'Security Guardian, Platform Guardian' -Hint 'see PREREQUISITES.md'
+
+    Write-Section 'Code Review Guardian Tools'
+    Test-Tool -Name 'ESLint'             -Command 'eslint'       -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'npm install -g eslint (see PREREQUISITES.md)'
+    Test-Tool -Name 'Ruff'               -Command 'ruff'         -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'pip install ruff (see PREREQUISITES.md)'
+    Test-Tool -Name 'Pylint'             -Command 'pylint'       -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'pip install pylint (see PREREQUISITES.md)'
+    Test-Tool -Name 'Clippy'             -Command 'cargo-clippy' -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'rustup component add clippy (see PREREQUISITES.md)'
+    Test-Tool -Name 'dotnet'             -Command 'dotnet'       -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'Maven (Checkstyle)' -Command 'mvn'          -VersionFlag '--version' -Guardian 'Code Review Guardian' -Hint 'see PREREQUISITES.md'
+
+    Write-Section 'Platform Guardian Tools'
+    Test-Tool -Name 'kubectl'    -Command 'kubectl'    -VersionFlag 'version --client' -Guardian 'Platform Guardian'                     -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'kube-bench' -Command 'kube-bench' -VersionFlag 'version'          -Guardian 'Platform Guardian'                     -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'kube-score' -Command 'kube-score' -VersionFlag 'version'          -Guardian 'Platform Guardian'                     -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'Polaris'    -Command 'polaris'    -VersionFlag 'version'          -Guardian 'Platform Guardian'                     -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'kubeaudit'  -Command 'kubeaudit'  -VersionFlag 'version'          -Guardian 'Platform Guardian'                     -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'Helm'       -Command 'helm'       -VersionFlag 'version --short'  -Guardian 'Platform Guardian, Delivery Guardian'  -Hint 'see PREREQUISITES.md'
+
+    Write-Section 'Delivery Guardian Tools'
+    Test-Tool -Name 'k6'        -Command 'k6' -VersionFlag 'version'    -Guardian 'Delivery Guardian, QA Guardian'         -Hint 'see PREREQUISITES.md'
+    Test-Tool -Name 'Azure CLI' -Command 'az' -VersionFlag '--version'  -Guardian 'Platform Guardian, Delivery Guardian'   -Hint 'see PREREQUISITES.md'
+
+    Write-Section 'Dependency Auditors'
+    Test-Tool -Name 'pip-audit'   -Command 'pip-audit'   -VersionFlag '--version' -Guardian 'Security Guardian' -Hint 'pip install pip-audit (see PREREQUISITES.md)'
+    Test-Tool -Name 'Bandit'      -Command 'bandit'      -VersionFlag '--version' -Guardian 'Security Guardian' -Hint 'pip install bandit (see PREREQUISITES.md)'
+    Test-Tool -Name 'Safety'      -Command 'safety'      -VersionFlag '--version' -Guardian 'Security Guardian' -Hint 'pip install safety (see PREREQUISITES.md)'
+    Test-Tool -Name 'cargo-audit' -Command 'cargo-audit' -VersionFlag '--version' -Guardian 'Security Guardian' -Hint 'cargo install cargo-audit (see PREREQUISITES.md)'
+    Test-Tool -Name 'cargo-deny'  -Command 'cargo-deny'  -VersionFlag '--version' -Guardian 'Security Guardian' -Hint 'cargo install cargo-deny (see PREREQUISITES.md)'
+
+    Write-Section 'Operator Tools'
+    Test-Tool -Name 'npx (Playwright MCP)' -Command 'npx' -VersionFlag '--version' -Guardian 'Operator' -Hint 'Install Node.js; then: npx @playwright/mcp@0.0.28 (see PREREQUISITES.md §7)'
+}
+
+function Doctor-CheckFiles {
+    Write-Section 'Guardian Files (installed to ~/.copilot/)'
+
+    foreach ($g in $Guardians) {
+        Test-Artifact -RelativePath "agents\$g.agent.md" -Description "$g.agent.md"
+    }
+    foreach ($g in $Guardians) {
+        Test-Artifact -RelativePath "instructions\$g.instructions.md" -Description "$g.instructions.md"
+    }
+    Test-Artifact -RelativePath 'instructions\sdlc-workflow.instructions.md' -Description 'sdlc-workflow.instructions.md'
+
+    Test-Artifact -RelativePath 'agents\operator.agent.md'                -Description 'operator.agent.md'
+    Test-Artifact -RelativePath 'instructions\operator.instructions.md'   -Description 'operator.instructions.md'
+
+    foreach ($skill in @('security-guardian', 'code-review-guardian', 'platform-guardian', 'privacy-guardian')) {
+        Test-Artifact -RelativePath "skills\$skill\SKILL.md" -Description "skills/$skill/"
+    }
+
+    Test-Artifact -RelativePath 'extensions\sdlc-guardian\extension.mjs'         -Description 'extensions/sdlc-guardian/extension.mjs'
+    Test-Artifact -RelativePath 'extensions\sdlc-guardian\uat-state-machine.mjs' -Description 'extensions/sdlc-guardian/uat-state-machine.mjs'
+    Test-Artifact -RelativePath 'extensions\craig\extension.mjs'                 -Description 'extensions/craig/extension.mjs'
+    Test-Artifact -RelativePath 'extensions\craig\craig-scheduler.mjs'           -Description 'extensions/craig/craig-scheduler.mjs'
+    Test-Artifact -RelativePath 'extensions\craig\craig-config.mjs'              -Description 'extensions/craig/craig-config.mjs'
+
+    Test-Artifact -RelativePath 'templates\feature-spec.template.md' -Description 'templates/feature-spec.template.md'
+
+    foreach ($g in $Guardians) {
+        Test-Artifact -RelativePath "instructions\$g.notes.md" -Description "$g.notes.md (side-notes)"
+    }
+
+    if ($script:DoctorFileMissing -gt 0) {
+        Write-Host ''
+        Write-Host '  Run ' -NoNewline -ForegroundColor DarkGray
+        Write-Host '.\package.ps1 -Install' -NoNewline -ForegroundColor Cyan
+        Write-Host ' to install Guardian files.' -ForegroundColor DarkGray
+    }
+}
+
+function Doctor-PrintSummary {
+    Write-Host ''
+    Write-Host '────────────────────────────────────────'
+    Write-Host ('Summary: {0}/{1} tools available. {2} optional missing. {3} core missing.' -f `
+        $script:DoctorAvailable, $script:DoctorTotal, $script:DoctorOptionalMissing, $script:DoctorCoreMissing)
+
+    if ($script:DoctorFileMissing -gt 0) {
+        Write-Host ('         {0}/{1} Guardian files installed. {2} missing.' -f `
+            $script:DoctorFileOk, $script:DoctorFileTotal, $script:DoctorFileMissing)
+    } else {
+        Write-Host ('         {0}/{1} Guardian files installed.' -f $script:DoctorFileOk, $script:DoctorFileTotal)
+    }
+
+    if ($script:DoctorCoreMissing -gt 0) {
+        Write-Host ''
+        Write-Host '✘ Core requirements missing.' -ForegroundColor Red
+        Write-Host 'Install them before using Guardians.'
+        exit 1
+    } else {
+        Write-Host ''
+        Write-Host '✔ Core requirements met.' -ForegroundColor Green
+        Write-Host 'Optional tools can be installed as needed.'
+    }
+}
+
+function Invoke-Doctor {
+    # Reset counters
+    $script:DoctorTotal           = 0
+    $script:DoctorAvailable       = 0
+    $script:DoctorOptionalMissing = 0
+    $script:DoctorCoreMissing     = 0
+    $script:DoctorFileTotal       = 0
+    $script:DoctorFileOk          = 0
+    $script:DoctorFileMissing     = 0
+
+    Write-Host ''
+    Write-Info '🩺 SDLC Guardian Agents — Doctor'
+    Write-Host 'Checking prerequisites...' -ForegroundColor DarkGray
+
+    Doctor-CheckTools
+    Doctor-CheckFiles
+    Doctor-PrintSummary
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Dispatch
+# ────────────────────────────────────────────────────────────────────────────
+
+if ($Install) {
+    Invoke-Package
+    Write-Host ''
+    Invoke-Install
+}
+elseif ($Uninstall) {
+    Invoke-Uninstall
+}
+elseif ($Doctor) {
+    Invoke-Doctor
+}
+else {
+    Invoke-Package
+}

--- a/package.sh
+++ b/package.sh
@@ -55,6 +55,7 @@ install() {
   mkdir -p "$TARGET_DIR/skills/privacy-guardian"
   mkdir -p "$TARGET_DIR/agents"
   mkdir -p "$TARGET_DIR/instructions"
+  mkdir -p "$TARGET_DIR/templates"
 
   # ── Install agents ──
   cp "$SRC_DIR/agents/security-guardian.agent.md" "$TARGET_DIR/agents/"
@@ -83,6 +84,9 @@ install() {
 
   # ── Install Craig instructions ──
   cp "$SRC_DIR/instructions/craig.instructions.md" "$TARGET_DIR/instructions/"
+
+  # ── Install templates (Spec Kit-compatible Formal Spec, etc.) ──
+  cp "$SRC_DIR/templates/feature-spec.template.md" "$TARGET_DIR/templates/"
 
   # ── Install skills (tool definitions only — no scripts) ──
   mkdir -p "$TARGET_DIR/skills/playwright-mcp"
@@ -171,6 +175,9 @@ install() {
   echo -e "${GREEN}✔${NC}  Extension:    ~/.copilot/extensions/sdlc-guardian/extension.mjs"
   echo -e "${GREEN}✔${NC}  State machine: ~/.copilot/extensions/sdlc-guardian/uat-state-machine.mjs"
   echo ""
+  echo -e "${BOLD}Templates:${NC}"
+  echo -e "${GREEN}✔${NC}  Feature Spec: ~/.copilot/templates/feature-spec.template.md (Spec Kit-compatible)"
+  echo ""
   echo -e "${BOLD}Side-Notes (advisory):${NC}"
   echo -e "${GREEN}✔${NC}  Notes: ${NOTES_CREATED} created, ${NOTES_EXISTED} preserved"
   echo ""
@@ -201,6 +208,10 @@ uninstall() {
   # ── Remove extensions ──
   [ -d "$TARGET_DIR/extensions/sdlc-guardian" ] && rm -rf "$TARGET_DIR/extensions/sdlc-guardian" && echo -e "${GREEN}✔${NC}  Removed ~/.copilot/extensions/sdlc-guardian/"
   [ -d "$TARGET_DIR/extensions/craig" ] && rm -rf "$TARGET_DIR/extensions/craig" && echo -e "${GREEN}✔${NC}  Removed ~/.copilot/extensions/craig/"
+
+  # ── Remove templates ──
+  [ -f "$TARGET_DIR/templates/feature-spec.template.md" ] && rm "$TARGET_DIR/templates/feature-spec.template.md" && echo -e "${GREEN}✔${NC}  Removed ~/.copilot/templates/feature-spec.template.md"
+  [ -d "$TARGET_DIR/templates" ] && rmdir "$TARGET_DIR/templates" 2>/dev/null && echo -e "${GREEN}✔${NC}  Removed empty ~/.copilot/templates/"
 
   echo ""
   echo -e "${GREEN}Done.${NC} Repo-level files (.github/) are untouched — remove per-repo if needed."

--- a/src/agents/code-review-guardian.agent.md
+++ b/src/agents/code-review-guardian.agent.md
@@ -234,8 +234,8 @@ After automated scans, review for issues tools cannot detect:
 - Acceptable values:
   - `Parent Spec: specs/{feature}/spec.md` — a spec is in play; proceed to drift check (8.2)
   - `Parent Spec: N/A — [explicit reason]` — spec was deliberately skipped; record the rationale, no drift check needed
-- **Failure mode (current):** if `Parent Spec:` is missing entirely, flag as a **finding** with severity 🟡 MEDIUM and tag `[SDLC-GUARDIAN]`. The finding text: "PR/ticket missing required `Parent Spec:` field — see PO Guardian Step 4b. Add either a spec path or a skip rationale."
-- **Future tightening:** once Phase 1–5 of issue #78 are stable in production use, this finding may be promoted to a blocking gate (severity 🔴 CRITICAL). Until then, flag-and-allow.
+- **Failure mode (permanent):** if `Parent Spec:` is missing entirely, flag as a **finding** with severity 🟡 MEDIUM and tag `[SDLC-GUARDIAN]`. The finding text: "PR/ticket missing required `Parent Spec:` field — see PO Guardian Step 4b. Add either a spec path or a skip rationale."
+- This is intentionally a warning, not a blocking gate. The judgment call about whether a spec was warranted belongs to the PO Guardian and the human reviewer — Code Review surfaces the gap rather than enforcing a hard rule.
 
 **8.2 Spec drift detection (when a parent spec exists)**
 

--- a/src/agents/code-review-guardian.agent.md
+++ b/src/agents/code-review-guardian.agent.md
@@ -26,7 +26,10 @@ Every finding MUST cite its source standard and explain WHY it's an issue:
 - `[MS-REVIEW]` — Microsoft Code Review Guidelines
 - `[CLEAN-CODE]` — Clean Code by Robert C. Martin
 - `[SOLID]` — SOLID Principles (SRP, OCP, LSP, ISP, DIP)
+- `[HEXAGONAL]` / `[CLEAN-ARCH]` — Hexagonal Architecture (Cockburn) / Clean Architecture (Martin)
 - `[PERF]` — Performance best practices
+- `[SPEC-DRIVEN]` — Spec-Driven Development principles (GitHub Spec Kit, Anthropic harness design)
+- `[SDLC-GUARDIAN]` — SDLC Guardian Agents project conventions (Formal Spec lifecycle, Parent Spec linkage)
 - `[CUSTOM]` — Project-specific rules
 
 Rate every finding: 🔴 **CRITICAL**, 🟠 **HIGH**, 🟡 **MEDIUM**, 🔵 **LOW**, ℹ️ **INFO**
@@ -220,6 +223,47 @@ After automated scans, review for issues tools cannot detect:
 - Outdated comments that contradict the code
 - Missing README updates for new features
 - Undocumented configuration options or environment variables
+
+#### Domain 8: Spec Drift & Linkage `[SPEC-DRIVEN]` `[SDLC-GUARDIAN]`
+
+> Capabilities #1 and #2 from issue #78. The Code Review Guardian is the **enforcer** of the Formal Spec lifecycle — drift detection per PR, bug-fix-patches-spec rule, and Parent Spec linkage. Spec content ownership stays with the PO Guardian (capability #2 — PO writes the patch; Code Review enforces that the patch happened).
+
+**8.1 Parent Spec linkage (required check)**
+
+- Inspect the PR description and ticket body for the `Parent Spec:` field (defined by PO Guardian Step 4b).
+- Acceptable values:
+  - `Parent Spec: specs/{feature}/spec.md` — a spec is in play; proceed to drift check (8.2)
+  - `Parent Spec: N/A — [explicit reason]` — spec was deliberately skipped; record the rationale, no drift check needed
+- **Failure mode (current):** if `Parent Spec:` is missing entirely, flag as a **finding** with severity 🟡 MEDIUM and tag `[SDLC-GUARDIAN]`. The finding text: "PR/ticket missing required `Parent Spec:` field — see PO Guardian Step 4b. Add either a spec path or a skip rationale."
+- **Future tightening:** once Phase 1–5 of issue #78 are stable in production use, this finding may be promoted to a blocking gate (severity 🔴 CRITICAL). Until then, flag-and-allow.
+
+**8.2 Spec drift detection (when a parent spec exists)**
+
+If the PR has `Parent Spec: specs/{feature}/spec.md`, read the spec and check whether the implementation in the diff still matches its intent:
+
+- **User Scenarios & Testing:** Does the implemented behavior match the user scenarios? If a P1 scenario is partially implemented or contradicted, flag 🟠 HIGH.
+- **Functional Requirements:** Does each `FR-NNN` in the spec have corresponding implementation (or test coverage proving the existing code already satisfies it)? Missing FR coverage → flag with severity matching the FR's MUST/SHOULD/MAY language.
+- **Success Criteria:** Are the measurable outcomes (`SC-NNN`) achievable with this implementation? If a SC is unmet or no longer measurable, flag 🟠 HIGH.
+- **Assumptions:** Has the implementation introduced or invalidated assumptions the spec relies on? If yes, the spec needs an update — flag 🟡 MEDIUM and recommend a spec patch.
+- **System Impact (Affected components/contracts):** Are the components and contracts the implementation actually touches a subset of those listed in the spec? If the implementation touches components NOT listed in System Impact, the spec under-described the change — flag 🟡 MEDIUM and recommend a spec patch.
+
+Drift findings recommend ONE of two remediations: (a) update the implementation to match the spec, or (b) update the spec to reflect intentional new direction. Do not silently allow drift.
+
+**8.3 Bug-fix → spec patch enforcement**
+
+If the PR is a bug-fix (heuristics: ticket labelled `bug`, branch named `fix/*` or `bugfix/*`, PR title contains "fix:" / "fixes #NNN"), check whether the parent spec was patched:
+
+- If `Parent Spec:` points to a real spec file and the PR diff does NOT modify that spec file → flag 🟠 HIGH with text: "Bug fix without spec patch. Bugs are evidence the originating spec was wrong (PO Guardian Step 4b bug-fix rule). Either patch `specs/{feature}/spec.md` to reflect what should be true, or document why the bug was a pure implementation defect with no spec implication."
+- If `Parent Spec: N/A — [reason]`, no enforcement needed (no spec to patch). Do NOT promote this to a finding.
+- If the spec file IS modified in the PR diff, record this as a **positive observation** in the report ("✅ Spec patched alongside fix") and proceed.
+
+**8.4 Spec hygiene (when reviewing a spec file change)**
+
+If the PR modifies any `specs/**/*.md` file:
+- Verify Sections 1–4 (Spec Kit-compatible) remain mechanically identical to the template structure (heading text, ID format `FR-NNN`, `SC-NNN`). Structural drift in the Spec Kit portion breaks compatibility — flag 🟠 HIGH.
+- Verify all `[NEEDS CLARIFICATION: ...]` markers introduced are either resolved within the same PR or surfaced as open questions in the PR description.
+- Verify the spec's `Last updated:` field was bumped.
+- Verify the spec's `Status:` field reflects reality (Draft / In Review / Approved / Implemented / Superseded).
 
 ### Step 3: Produce the Handoff Report
 Combine ALL automated findings + manual findings into one structured report.

--- a/src/agents/operator.agent.md
+++ b/src/agents/operator.agent.md
@@ -27,6 +27,7 @@ When invoked directly, ask what task to run. When invoked as a subagent, infer f
 - ✅ Monitor health endpoints (HTTP checks via `curl`)
 - ✅ Run errands — fetch data, extract metrics, execute user-defined tasks
 - ✅ Housekeeping — list worktrees, prune stale branches, check disk usage
+- ✅ Archive shipped features — produce curated `archive/{feature}.md` digests on merge (capability #5 from issue #78)
 
 ## What You Do NOT Do
 
@@ -304,6 +305,129 @@ ORDER BY rank LIMIT 100;
 **If it fails:**
 - If `git worktree remove` fails (e.g., worktree has uncommitted changes), report the error and skip that worktree.
 - Never force-remove worktrees — always use the safe `git worktree remove` (not `--force`).
+
+---
+
+### Procedure 6: Feature Archive (post-merge)
+
+> Capability #5 from issue #78. Curates a shipped-feature digest from the Formal Spec, tickets, PR diff, and Guardian reports, producing a single human-readable record that survives independent of the issue tracker.
+
+**Tools:** bash (`gh`, `git`), session_store SQL, file I/O
+**Risk level:** LOW (read-only on remote sources, write to target project's `archive/` dir)
+**Triggered by:** Orchestrator on merge of a feature ticket (capability #5 — see Phase 5 of issue #78). Can also be invoked manually.
+
+**Inputs (from the dispatching prompt):**
+- `feature_slug` — kebab-case identifier, matches `specs/{feature_slug}/spec.md`
+- `merged_pr_numbers` — list of PRs that delivered the feature
+- `target_project_dir` — absolute path to the target project repo (where `archive/` will be written)
+
+**Steps:**
+
+1. **Locate the parent spec.** Read `{target_project_dir}/specs/{feature_slug}/spec.md` if it exists.
+   - If missing AND the feature was shipped via tickets that all carry `Parent Spec: N/A — [reason]`, that is acceptable — note "No Formal Spec — feature shipped under skip rationale" in the archive.
+   - If missing AND any ticket carries `Parent Spec: specs/{feature_slug}/spec.md` (file gone or path mismatch), flag this as an archive integrity issue and continue with what you can find.
+
+2. **Collect tickets.** For each PR in `merged_pr_numbers`, run `gh pr view {N} --json title,body,number,closingIssuesReferences,mergedAt,headRefName`. Extract the linked tickets via `closingIssuesReferences`. For each ticket, run `gh issue view {N} --json title,body,number,labels,closedAt`.
+
+3. **Collect PR diffs.** For each PR, capture the diff stat: `gh pr diff {N} --name-only` and the summary stats from `gh pr view {N} --json additions,deletions,changedFiles`. Do NOT include the full diff in the archive — link to the PR for the source.
+
+4. **Collect Guardian reports.** Query the session_store for Guardian session events tied to these PRs/tickets:
+   ```sql
+   SELECT s.id, s.agent_name, s.summary, s.created_at
+   FROM sessions s
+   JOIN session_refs r ON r.session_id = s.id
+   WHERE r.ref_type = 'pr' AND r.ref_value IN ({merged_pr_numbers})
+     AND s.agent_name IN ('QA Guardian', 'Security Guardian', 'Privacy Guardian', 'Code Review Guardian', 'Platform Guardian', 'Delivery Guardian')
+   ORDER BY s.created_at DESC;
+   ```
+   Pull the final assistant message from each session as the Guardian's verdict (or use the session summary if present).
+
+5. **Compose the archive document** at `{target_project_dir}/archive/{feature_slug}.md` using this structure:
+
+   ```markdown
+   # Archive — {Feature Name}
+
+   **Shipped:** {merged_at of latest PR}
+   **Feature slug:** `{feature_slug}`
+   **Parent Spec:** `specs/{feature_slug}/spec.md` (or "N/A — [skip rationale]")
+   **PRs:** #{N1}, #{N2}, ...
+   **Tickets:** #{T1}, #{T2}, ...
+
+   ## What shipped
+
+   {1-paragraph summary derived from spec Section 1.1 (Problem) + 1.2 (Goal),
+    or from the highest-priority ticket title/body if no spec.}
+
+   ## Spec snapshot (at time of merge)
+
+   - **User scenarios delivered:** {bulleted list from spec Section "User Scenarios & Testing", marked which P-levels shipped}
+   - **Functional requirements satisfied:** {FR-NNN list with one-line summaries}
+   - **Success criteria targeted:** {SC-NNN list — note these are TARGETS at merge time, not validated outcomes}
+   - **Assumptions in force:** {bulleted list — readers consulting the archive years later need to know what was assumed true}
+
+   _If no spec: "No Formal Spec — see ticket bodies linked above for intent."_
+
+   ## What changed in the system
+
+   ### Affected components and contracts
+   {From spec Section "System Impact → Affected components" / "Affected contracts".
+    If no spec, derive a coarse list from the PR's `--name-only` file paths, grouped by directory.}
+
+   ### Backward compatibility
+   {From spec Section "System Impact → Backward compatibility and migration".
+    If no spec: "Not formally documented at merge time."}
+
+   ### Risk surface
+   {From spec Section "System Impact → Risk surface".
+    If no spec: "Not formally documented at merge time."}
+
+   ## Product impact (at time of merge)
+
+   {From spec Section "Product Impact". If no spec, omit this section.}
+
+   ## Guardian verdicts
+
+   For each Guardian session linked to the PRs:
+
+   ### {Guardian name} — session {session_id}
+   _{created_at}_
+
+   {Final summary from the session — 3–6 lines, copied verbatim from the
+    Guardian's final report. Do NOT paraphrase. If the session is too long
+    to summarize fairly, link to it in the session_store and note the link.}
+
+   ## PR summary
+
+   | PR | Title | Files | +/− | Branch |
+   |---|---|---|---|---|
+   | #{N} | {title} | {changedFiles} | +{additions}/-{deletions} | `{headRefName}` |
+
+   ## Notes
+
+   - Archive curated by the Operator at {ISO timestamp}, post-merge.
+   - This archive is a snapshot. The spec, tickets, and PRs are the source of truth — the archive is the readable index.
+   ```
+
+6. **Validate the archive** before returning:
+   - The Markdown must render without breaks (lint with a basic check or visual inspection).
+   - All linked PRs and tickets must resolve via `gh`.
+   - All Guardian session IDs must exist in the session_store.
+   - The spec snapshot section must NOT contain `[NEEDS CLARIFICATION:]` markers — if found, flag them in the archive's Notes section ("Spec had unresolved clarifications at merge — see {ticket}").
+
+7. **Apply redaction** per the standard Report Redaction rules (no secrets, no PII).
+
+8. **Write the archive** to `{target_project_dir}/archive/{feature_slug}.md`. Create the `archive/` directory if it does not exist. Do NOT commit — committing is the human's decision.
+
+9. **Report back** with the archive path, the count of PRs/tickets/Guardian-sessions referenced, and any integrity issues flagged in step 1 or step 6.
+
+**If it fails:**
+- If the session_store query returns no Guardian sessions, the archive is incomplete but still valuable — write it with a "No Guardian sessions found in store" note. Do not abort.
+- If `gh pr view` fails for a PR (e.g., PR deleted), record the PR number with "details unavailable" in the PR summary table.
+- Never invent Guardian verdicts. If a session is missing, the section is missing — say so.
+
+**If invoked manually (not via Orchestrator):**
+- Ask the user for `feature_slug` and `merged_pr_numbers` if not provided.
+- Default `target_project_dir` to the current working directory.
 
 ---
 

--- a/src/agents/po-guardian.agent.md
+++ b/src/agents/po-guardian.agent.md
@@ -85,6 +85,39 @@ Scan for these files and assess whether they exist and are complete:
 - web_search for industry patterns and similar implementations
 - Search GitHub repos for open-source reference implementations
 
+### Step 4b: Decide on Formal Spec (Spec Kit-compatible)
+
+After research is complete and BEFORE decomposition, decide whether this work warrants a **Formal Spec** — a single readable artifact stored at `specs/{feature}/spec.md` in the target project repo. The spec aggregates the output of Steps 1–5b into a holistic, system-aware view that developers, reviewers, and AI agents can consume in one read.
+
+The Formal Spec is **Spec Kit-compatible** (https://github.com/github/spec-kit) — Sections "User Scenarios & Testing", "Requirements", "Success Criteria", and "Assumptions" are mechanically identical to Spec Kit's `spec-template.md`. SDLC Guardian extensions (Decomposition, Guardian Consultation Results, System Impact, Product Impact) sit on top.
+
+#### When to produce a Formal Spec
+
+**Per-request judgment, not a fixed threshold.** Decide based on whether the artifact adds clarity proportional to the ceremony cost.
+
+- **Produce when:** the work involves multi-component changes, cross-Guardian impact, architectural shifts, new product surfaces, or a decomposition tree of any meaningful depth.
+- **Skip when:** the work is a trivial bug fix, a single-component refactor, a hotfix, or any change where the 18-section ticket alone captures everything a reviewer needs.
+
+Either way, **capture the decision and rationale** in the parent ticket(s) via the `Parent Spec:` field:
+- `Parent Spec: specs/{feature}/spec.md` — when a spec is produced
+- `Parent Spec: N/A — [explicit reason, e.g., "single-line config fix; no system impact"]` — when skipped
+
+The skip rationale must be visible in the ticket. Silence is not acceptable.
+
+#### How the Formal Spec is populated
+
+The spec is **derived from work you already do** — you do not perform new research. The sections are populated incrementally:
+
+| Spec section | Populated from |
+|---|---|
+| User Scenarios & Testing, Requirements, Success Criteria, Assumptions | Steps 1, 2, 2b, 3, 4 |
+| Decomposition | Step 5 |
+| Guardian Consultation Results | Step 5b |
+| System Impact | Step 2 (codebase research) + Step 5b consultations + (Phase 2: Code Review consultation for architectural impact) |
+| Product Impact | Step 1 (understanding the request) + user-provided context |
+
+If you decide to produce a spec, stub the file at `specs/{feature}/spec.md` using the template at `~/.copilot/templates/feature-spec.template.md` now, then fill it as you progress through Steps 5–5b. Finalize in Step 5c.
+
 ### Step 5: Decompose before detailing
 
 **Do NOT try to spec everything in one ticket.** Large requests must be broken down first.
@@ -173,6 +206,21 @@ Skip for internal tools, libraries, or changes with no deployment impact.
 
 This step prevents the common pattern where review Guardians find missing requirements AFTER implementation — catching them at spec time saves a full rework cycle.
 
+**If a Formal Spec is in progress**, populate its **Guardian Consultation Results** section now — capture each Guardian's input once at the feature level rather than repeating it across every ticket.
+
+### Step 5c: Finalize Formal Spec (when warranted)
+
+If a Formal Spec was started in Step 4b, finalize it now — before writing the detailed tickets in Step 6. Verify:
+
+- All Spec Kit-compatible sections (User Scenarios & Testing, Requirements, Success Criteria, Assumptions) are filled with concrete, measurable content
+- All `[NEEDS CLARIFICATION: ...]` markers are resolved (or surfaced to the user as blocking questions)
+- The **Decomposition** section reflects the agreed module/ticket tree from Step 5
+- The **Guardian Consultation Results** section captures every consulted Guardian's input from Step 5b
+- The **System Impact** section explicitly addresses affected components, contracts, architectural deltas, backward compatibility, and risk surface — this is the section most often skimped; do not let it be vague
+- The **Product Impact** section addresses positioning, scope, roadmap dependencies, and user-facing communication
+
+Save the spec at `specs/{feature}/spec.md` in the target project repo and link it from the parent issue/epic. Each ticket created in Step 6 must reference it via the `Parent Spec:` field.
+
 ### Step 6: Write the ticket(s)
 
 Use the application type to determine which checklist questions need deep answers vs. N/A. Write each ticket following the template below.
@@ -197,6 +245,8 @@ Before finalizing, verify:
 
 ```markdown
 # [Feature Title]
+
+**Parent Spec**: `specs/{feature}/spec.md` — OR — `N/A — [explicit reason for skipping the Formal Spec, e.g., "trivial bug fix; no system impact"]`
 
 <!-- ═══════════════════════════════════════════════════════ -->
 <!-- PRODUCT — what we're building and for whom             -->

--- a/src/agents/po-guardian.agent.md
+++ b/src/agents/po-guardian.agent.md
@@ -76,6 +76,43 @@ Scan for these files and assess whether they exist and are complete:
 
 **Do NOT silently assume or skip.** If you don't have the context, ask for it.
 
+### Step 2c: Check for existing Formal Specs (brownfield bootstrap)
+
+After confirming project documentation, check whether the area being changed already has a **parent Formal Spec** at `specs/{feature}/spec.md`.
+
+#### If a parent spec exists
+
+- Read it. The spec is the source of truth for intent, system impact, and product impact in this area.
+- Validate that the proposed change aligns with the spec's User Scenarios, Requirements, and Success Criteria. If it does NOT align, the spec may need a patch — flag this for Step 4b (decide) and Step 5c (finalize).
+- The new ticket(s) you produce in Step 6 will reference this spec via the `Parent Spec:` field.
+
+#### If NO parent spec exists (brownfield)
+
+This is the common case when SDLC Guardian Agents is adopted on an existing codebase. You have two paths:
+
+**Path A — Bootstrap a spec from current code (when warranted):**
+
+- Use this path if the area being changed is non-trivial AND will see further work over time. A bootstrapped spec captures *what the system does today* so future changes have a baseline to evolve from.
+- Procedure:
+  1. Identify the affected area (component, module, subsystem) by reading the codebase
+  2. Stub `specs/{feature}/spec.md` from the template at `~/.copilot/templates/feature-spec.template.md`
+  3. Fill **Section 1 (Spec Kit-compatible)** by reverse-engineering current behavior:
+     - User Scenarios = inferred from existing UX, API endpoints, or CLI commands
+     - Requirements = inferred from existing tests, validation logic, error handling
+     - Success Criteria = inferred from observable behavior, SLAs in code/config, or — if undefined — marked `[NEEDS CLARIFICATION: not previously documented]`
+     - Assumptions = inferred from preconditions in code; explicit assumptions get explicit entries
+  4. Fill **System Impact** with the *current* component/contract surface — this becomes the baseline against which the new change's deltas are measured
+  5. Mark the spec **Status: Draft (bootstrapped from existing code)** so reviewers know the source
+  6. Present the bootstrapped spec to the user for confirmation before adding the new change's content
+- The bootstrapped spec covers existing behavior. The new change extends it via Steps 4b–5c.
+
+**Path B — Skip the bootstrap (when ceremony exceeds value):**
+
+- Use this path for trivial changes to legacy code that is already slated for replacement, hotfixes that won't recur, or one-off scripts.
+- Document the skip rationale in the ticket's `Parent Spec:` field as `N/A — [reason, e.g., "isolated hotfix to legacy module marked for deprecation"]`.
+
+**Do NOT silently bootstrap.** Bootstrapping reverse-engineers intent from code, which may capture *what the system does* rather than *what it should do*. Always present the bootstrapped spec for user review and correction before treating it as the source of truth.
+
 ### Step 3: Search existing issues and PRs
 - Search GitHub issues for related keywords
 - Check open PRs for in-progress related work
@@ -113,10 +150,24 @@ The spec is **derived from work you already do** — you do not perform new rese
 | User Scenarios & Testing, Requirements, Success Criteria, Assumptions | Steps 1, 2, 2b, 3, 4 |
 | Decomposition | Step 5 |
 | Guardian Consultation Results | Step 5b |
-| System Impact | Step 2 (codebase research) + Step 5b consultations + (Phase 2: Code Review consultation for architectural impact) |
+| System Impact | Step 2 (codebase research) + Step 5b consultations + Step 5b-arch (Code Review architectural-impact consultation) |
 | Product Impact | Step 1 (understanding the request) + user-provided context |
 
-If you decide to produce a spec, stub the file at `specs/{feature}/spec.md` using the template at `~/.copilot/templates/feature-spec.template.md` now, then fill it as you progress through Steps 5–5b. Finalize in Step 5c.
+If you decide to produce a spec, stub the file at `specs/{feature}/spec.md` using the template at `~/.copilot/templates/feature-spec.template.md` now, then fill it as you progress through Steps 5–5b-arch. Finalize in Step 5c.
+
+#### Bug-fix tickets — special rule
+
+Bugs are **evidence the spec was wrong** (or never existed). When you write a bug-fix ticket, decide on Formal Spec patching as part of Step 4b:
+
+| Situation | Action |
+|---|---|
+| The bug area has a parent spec (found in Step 2c) | **PATCH the spec** as part of this ticket. Update the User Scenarios, Requirements, Success Criteria, or Assumptions section that the bug exposed as incorrect. The bug fix and the spec patch ship together. |
+| The bug area has no parent spec AND the area is non-trivial | **Bootstrap a spec** (Step 2c Path A). The bug fix ships with the bootstrapped spec; future changes to this area now have a baseline. |
+| The bug area has no parent spec AND the area is trivial / scheduled for replacement | **Skip** — `Parent Spec: N/A — [reason]`. No new spec, no patch. |
+
+When patching a spec, the ticket's `Parent Spec:` field still points to the spec file. The PR will modify both the code and the spec — Code Review enforces this in Phase 3 (capability #2 from issue #78).
+
+Do **not** ship a bug fix that contradicts an existing spec without updating the spec. Drift between code and spec is the failure mode this rule prevents.
 
 ### Step 5: Decompose before detailing
 
@@ -207,6 +258,22 @@ Skip for internal tools, libraries, or changes with no deployment impact.
 This step prevents the common pattern where review Guardians find missing requirements AFTER implementation — catching them at spec time saves a full rework cycle.
 
 **If a Formal Spec is in progress**, populate its **Guardian Consultation Results** section now — capture each Guardian's input once at the feature level rather than repeating it across every ticket.
+
+### Step 5b-arch: Consult Code Review Guardian for architectural impact (when a Formal Spec is in progress)
+
+If a Formal Spec is in progress, consult the **Code Review Guardian** as a subagent to assess the architectural impact of the change BEFORE finalizing the spec. The Code Review Guardian's design-review expertise produces the substance of the spec's **System Impact** section (capability #4 from issue #78).
+
+> "I'm specifying [feature summary] in [project]. The current architecture is [brief description from Step 2 codebase research / from the bootstrapped spec if Step 2c produced one]. Assess the architectural impact of this change: which existing components and contracts are affected, what architectural assumptions change, what backward-compatibility concerns arise, and what is the new risk surface? Cite SOLID, Clean Architecture, or Well-Architected principles where they apply."
+
+**How to incorporate the response:**
+- Populate the spec's **System Impact → Affected components** table from the Code Review Guardian's component list
+- Populate **Affected contracts** from the contract surface they identified (APIs, schemas, env vars, CLI flags)
+- Populate **Architectural deltas** from the assumptions the Guardian flags as changing
+- Populate **Backward compatibility and migration** from their compat assessment
+- Populate **Risk surface** with both risks introduced and risks reduced
+- Add to the spec's **Guardian Consultation Results → Code Review Guardian (architectural impact)** subsection: a one-line summary of each finding with severity
+
+Skip this step if no Formal Spec is being produced (per Step 4b decision). The 18-section ticket alone does not require this consultation.
 
 ### Step 5c: Finalize Formal Spec (when warranted)
 

--- a/src/extensions/sdlc-guardian/uat-state-machine.mjs
+++ b/src/extensions/sdlc-guardian/uat-state-machine.mjs
@@ -183,7 +183,7 @@ export function buildPostImplementationContext(fileCount) {
     "Otherwise ask the user: 'Would you like to manually test before the full review pipeline? (Yes / Skip)'",
     "If the user opts in, enter the UAT loop — let them test and pair-fix with Developer Guardian.",
     "After UAT is done or skipped, run the mandatory review gate: QA + Security + Code Review in parallel.",
-    "Security and QA use claude-opus-4.6. Code Review stays dual-model: Opus 4.6 + GPT-5.4.",
+    "Security and QA use claude-opus-4.7. Code Review stays dual-model: Opus 4.7 + GPT-5.5.",
   ].join("\n");
 }
 

--- a/src/instructions/code-review-guardian.instructions.md
+++ b/src/instructions/code-review-guardian.instructions.md
@@ -5,8 +5,8 @@ ALL code review tasks (quality checks, linting, design review, code analysis) MU
 **IMPORTANT: Always launch TWO instances in parallel with different models for independent perspectives.**
 
 **How:** Use the task tool to launch TWO Code Review Guardian agents simultaneously, both in `mode: "background"`:
-1. First instance with `model: "claude-opus-4.6"` (Claude Opus 4.6)
-2. Second instance with `model: "gpt-5.4"` (GPT 5.4)
+1. First instance with `model: "claude-opus-4.7"` (Claude Opus 4.7)
+2. Second instance with `model: "gpt-5.5"` (GPT 5.5)
 
 Both receive the same prompt and review the same code independently. When both complete, **merge the results** — deduplicate findings, note where both models agree (higher confidence), and flag findings that only one model caught (may need human judgment).
 

--- a/src/instructions/code-review-guardian.instructions.md
+++ b/src/instructions/code-review-guardian.instructions.md
@@ -12,7 +12,13 @@ Both receive the same prompt and review the same code independently. When both c
 
 **Trigger words:** "review code", "check code quality", "lint", "code review", "review my changes", "review this PR"
 
-**Do NOT** run linters yourself or do your own pre-analysis. The agents run the linters, then analyze architecture, design, testing, naming, performance, and documentation against Google Engineering Practices, Microsoft guidelines, and Clean Code principles.
+**Do NOT** run linters yourself or do your own pre-analysis. The agents run the linters, then analyze architecture, design, testing, naming, performance, documentation, and **Formal Spec drift & linkage** (Domain 8 — Spec Kit-compatible specs at `specs/{feature}/spec.md`) against Google Engineering Practices, Microsoft guidelines, Clean Code principles, and SDLC Guardian conventions.
+
+**Spec-aware review (Domain 8 — capabilities #1 and #2 from issue #78):**
+- Verify every PR/ticket carries a `Parent Spec:` field (path or `N/A — [reason]`)
+- When a parent spec exists, check the implementation for drift against the spec's User Scenarios, Requirements, Success Criteria, Assumptions, and System Impact
+- Bug-fix PRs against an area with a parent spec MUST also patch the spec (PO Guardian Step 4b bug-fix rule)
+- Spec file changes themselves get hygiene checks (Spec Kit Sections 1–4 must remain mechanically identical, `Last updated:` bumped, `[NEEDS CLARIFICATION:]` markers resolved)
 
 **After both agents report:**
 1. Merge findings — deduplicate, combine severity assessments

--- a/src/instructions/operator.instructions.md
+++ b/src/instructions/operator.instructions.md
@@ -1,15 +1,17 @@
 # Operator — Auto-Delegation
 
-When the user asks to take screenshots, generate reports, check health endpoints, run operational errands, or perform housekeeping tasks, delegate IMMEDIATELY to the Operator agent via the task tool with **`mode: "background"`**.
+When the user asks to take screenshots, generate reports, check health endpoints, run operational errands, perform housekeeping tasks, or **archive a shipped feature**, delegate IMMEDIATELY to the Operator agent via the task tool with **`mode: "background"`**.
 
-**Trigger words:** "take a screenshot", "capture the page", "generate a report", "weekly recap", "check health", "health endpoint", "monitor", "clean up worktrees", "prune branches", "disk usage", "fetch data from", "scrape", "screenshot", "Grafana", "dashboard screenshot", "morning dashboard"
+**Trigger words:** "take a screenshot", "capture the page", "generate a report", "weekly recap", "check health", "health endpoint", "monitor", "clean up worktrees", "prune branches", "disk usage", "fetch data from", "scrape", "screenshot", "Grafana", "dashboard screenshot", "morning dashboard", "archive this feature", "archive the feature", "shipped-feature digest", "post-merge archive"
 
-**Do NOT** run operational tasks yourself. The Operator handles screenshots (via Playwright MCP), reports (via session_store), health checks (via curl), errands (data fetching), and housekeeping (worktrees, branches, disk). It follows the Command Risk Classification from `sdlc-workflow.instructions.md` and saves results to `~/.copilot/reports/`.
+**Do NOT** run operational tasks yourself. The Operator handles screenshots (via Playwright MCP), reports (via session_store), health checks (via curl), errands (data fetching), housekeeping (worktrees, branches, disk), and **post-merge feature archives** (curating spec + tickets + PR diff + Guardian reports into `archive/{feature}.md` — Procedure 6, capability #5 from issue #78). It follows the Command Risk Classification from `sdlc-workflow.instructions.md` and saves task output to `~/.copilot/reports/` (operational tasks) or to the target project's `archive/` directory (feature archives).
 
 **Craig routing:** When Craig dispatches a prompt for an operational task, the orchestrator recognizes it and delegates to the Operator. Craig prompts may use a prefix like `"Operator: do X"` to signal routing. The orchestrator dispatches to the Operator agent in background mode.
+
+**Orchestrator post-merge hook:** When a feature ticket is merged, the Orchestrator dispatches the Operator with the feature slug, merged PR numbers, and target project directory. The Operator runs Procedure 6 to produce `{target_project_dir}/archive/{feature_slug}.md`. This is automatic — the Operator does NOT commit the archive file; that decision is left to the human.
 
 **Background execution:** The Operator MUST always run in `mode: "background"` so the user's coding session is not blocked. The user gets notified on completion via standard system notification.
 
 **Playwright MCP:** If the user requests a browser task and Playwright MCP is not available, the Operator reports the gap and suggests installation (see PREREQUISITES.md §7). Non-browser tasks work without Playwright.
 
-**Procedures:** Detailed step-by-step procedures for all 5 task types are defined in `operator.agent.md`.
+**Procedures:** Detailed step-by-step procedures for all 6 task types (Screenshot, Report, Health Monitoring, Errands, Housekeeping, Feature Archive) are defined in `operator.agent.md`.

--- a/src/instructions/po-guardian.instructions.md
+++ b/src/instructions/po-guardian.instructions.md
@@ -17,9 +17,11 @@ When the user describes a feature, reports a bug, asks to create a ticket, write
 **Workflow:**
 1. PO Guardian researches and **decomposes** the request into modules/tickets
 2. PO Guardian **decides per-request whether a Formal Spec is warranted** (Step 4b) — multi-component / cross-Guardian / architectural shifts produce a Spec Kit-compatible spec at `specs/{feature}/spec.md`; trivial work skips it. Decision and rationale are captured in every ticket via the `Parent Spec:` field.
-3. PO Guardian presents the decomposition (and spec, if produced) to the user for approval
-4. PO Guardian details each ticket with the 18-section template (each ticket carries a `Parent Spec:` line)
-5. PO Guardian creates issues in the project's tracker
-6. Orchestrator presents the specs to the user — no summarizing
-7. User confirms, requests changes, or answers open questions
-8. Only then does the orchestrator invoke the Developer Guardian
+3. **For brownfield projects** (Step 2c) — when the area being changed has no parent spec, the PO Guardian bootstraps one from the existing code so the new change has a baseline to evolve from. Bug fixes against an area with a spec **patch the spec** as part of the ticket.
+4. **For non-trivial work** (Step 5b-arch) — the PO Guardian consults the Code Review Guardian for architectural-impact assessment, which feeds the spec's System Impact section.
+5. PO Guardian presents the decomposition (and spec, if produced) to the user for approval
+6. PO Guardian details each ticket with the 18-section template (each ticket carries a `Parent Spec:` line)
+7. PO Guardian creates issues in the project's tracker
+8. Orchestrator presents the specs to the user — no summarizing
+9. User confirms, requests changes, or answers open questions
+10. Only then does the orchestrator invoke the Developer Guardian

--- a/src/instructions/po-guardian.instructions.md
+++ b/src/instructions/po-guardian.instructions.md
@@ -16,9 +16,10 @@ When the user describes a feature, reports a bug, asks to create a ticket, write
 
 **Workflow:**
 1. PO Guardian researches and **decomposes** the request into modules/tickets
-2. PO Guardian presents the decomposition to the user for approval
-3. PO Guardian details each ticket with the 18-section template
-4. PO Guardian creates issues in the project's tracker
-5. Orchestrator presents the specs to the user — no summarizing
-6. User confirms, requests changes, or answers open questions
-7. Only then does the orchestrator invoke the Developer Guardian
+2. PO Guardian **decides per-request whether a Formal Spec is warranted** (Step 4b) — multi-component / cross-Guardian / architectural shifts produce a Spec Kit-compatible spec at `specs/{feature}/spec.md`; trivial work skips it. Decision and rationale are captured in every ticket via the `Parent Spec:` field.
+3. PO Guardian presents the decomposition (and spec, if produced) to the user for approval
+4. PO Guardian details each ticket with the 18-section template (each ticket carries a `Parent Spec:` line)
+5. PO Guardian creates issues in the project's tracker
+6. Orchestrator presents the specs to the user — no summarizing
+7. User confirms, requests changes, or answers open questions
+8. Only then does the orchestrator invoke the Developer Guardian

--- a/src/instructions/sdlc-workflow.instructions.md
+++ b/src/instructions/sdlc-workflow.instructions.md
@@ -16,6 +16,8 @@ Check: is there an issue (GitHub, Azure DevOps, or equivalent) or PO Guardian ti
 - If **yes** → proceed to step 3
 - If **no** → invoke PO Guardian first to create the specification
 
+The PO Guardian will also decide whether the work warrants a **Formal Spec** at `specs/{feature}/spec.md` (Spec Kit-compatible — see PO Guardian Step 4b). Multi-component, cross-Guardian, or architecturally significant work produces a spec; trivial work skips it. Either way, every ticket carries a `Parent Spec:` field capturing the decision.
+
 Do NOT allow implementation without a specification. Say:
 > "There's no ticket for this yet. Let me invoke the PO Guardian to spec it out first."
 
@@ -135,11 +137,57 @@ The Developer Guardian creates the PR and pushes to the ticket branch. The pre-m
 1. All Guardian reviews (QA, Security, Privacy, Code Review) completed
 2. All remote CI checks pass (build, tests, security scans)
 3. No unresolved critical/high findings
-4. Present the combined report to the user
-5. User confirms: **merge approved**
+4. **Spec linkage and drift checks pass** (Code Review Guardian Domain 8 — capabilities #1 and #2 from issue #78):
+   - Every PR carries a `Parent Spec:` field (path or `N/A — [reason]`)
+   - When a parent spec exists, no unresolved drift findings against User Scenarios, Requirements, Success Criteria, or System Impact
+   - Bug-fix PRs against an area with a parent spec have patched the spec
+5. Present the combined report to the user
+6. User confirms: **merge approved**
 
 If any Guardian review is missing or has unresolved findings, say:
 > "All CI checks pass, but Security Guardian has 2 high findings unresolved. Address them before merging?"
+
+## Post-Merge Archive Gate — AUTOMATIC
+
+**Immediately after a feature ticket merges, dispatch the Operator to archive the shipped work.**
+
+Capability #5 from issue #78. The archive is a curated post-merge digest combining the parent spec, tickets, PR diff, and Guardian session reports into a single human-readable record at `{target_project_dir}/archive/{feature_slug}.md`.
+
+**Trigger conditions:**
+- A PR was just merged
+- The PR closed at least one feature/bug ticket (`closingIssuesReferences` is non-empty)
+- The ticket(s) carry a `Parent Spec:` field — either pointing to a spec file or `N/A — [reason]`
+
+**Orchestrator action:**
+
+```
+On merge:
+  1. Determine feature_slug from the parent spec path (specs/{feature_slug}/spec.md)
+     OR from the dominant ticket title slug if Parent Spec is N/A
+  2. Collect merged_pr_numbers (the just-merged PR + any sibling PRs in the
+     same feature branch series, if applicable)
+  3. Determine target_project_dir (the repo root of the merged PR)
+  4. Dispatch the Operator in mode: "background" with this prompt:
+
+     "Operator: Procedure 6 — Feature Archive.
+      feature_slug: {slug}
+      merged_pr_numbers: {N1, N2, ...}
+      target_project_dir: {abs_path}
+      Produce archive/{feature_slug}.md per the procedure."
+
+  5. When the Operator completes, present the archive path to the user
+     with a short summary (PRs/tickets/Guardian sessions referenced).
+     The Operator does NOT commit the archive — the user decides whether
+     to add it to the repo.
+```
+
+**Skip conditions (do NOT dispatch):**
+- The merged PR does not close any tickets (e.g., a docs-only PR with no associated work item)
+- All closed tickets have `Parent Spec: N/A — [reason: trivial fix]` AND the PR is small (< 50 lines diff). The archive overhead exceeds value for trivial fixes that nobody will look back at.
+- Craig is currently disabled AND the user has not explicitly opted into archiving (rare — Craig being enabled is the default once installed).
+
+**On Operator failure (partial archive):**
+- The Operator returns its archive even with missing inputs (no Guardian sessions found, PR view failed, etc.). The orchestrator still presents the archive to the user with the integrity issues flagged, rather than discarding the work.
 
 ## Pre-Deployment Gate
 
@@ -160,6 +208,11 @@ When the user asks to deploy, release, or push to an environment:
   ├─ No ticket? → PO Guardian (auto, interactive)
   ↓
 🎯 PO Guardian creates issue in tracker
+  │     └─ Step 2c: brownfield bootstrap (specs/{feature}/spec.md from existing code)
+  │     └─ Step 4b: decide on Formal Spec — multi-component / cross-Guardian / architectural?
+  │     └─ Step 5b-arch: consult Code Review for architectural impact (when spec produced)
+  │     └─ Step 5c: finalize Spec Kit-compatible spec at specs/{feature}/spec.md
+  │     └─ Every ticket carries Parent Spec field (path or N/A — rationale)
   ↓
 📋 Orchestrator presents FULL spec to user
   ↓
@@ -174,13 +227,18 @@ When the user asks to deploy, release, or push to an environment:
   ├─ 🧪 QA Guardian ──────────┐
   ├─ 🛡️ Security Guardian ────┤ (parallel, background)
   ├─ 🔒 Privacy Guardian ─────┤
-  ├─ 📋 Code Review Guardian ─┘
+  ├─ 📋 Code Review Guardian ─┘ (Domain 8: spec drift + Parent Spec linkage)
   ↓
   Combined results → fix critical/high → commit
   ↓
   ├─ Deploy? → ⚙️ Platform Guardian + 🚀 Delivery Guardian (auto)
   ↓
-  PR / Merge / Deploy
+  PR / Merge
+  ↓
+📚 Operator archives shipped feature (auto on merge)
+   → archive/{feature_slug}.md (spec + tickets + PR diff + Guardian verdicts)
+  ↓
+  Deploy
 ```
 
 ## Iteration & Consultation Pattern

--- a/src/instructions/sdlc-workflow.instructions.md
+++ b/src/instructions/sdlc-workflow.instructions.md
@@ -326,4 +326,4 @@ This applies to all Guardian-to-user and Guardian-to-Guardian communication thro
 - **Diff-only on re-iteration** — second pass reviews only what changed
 - **User decides, not the agent** — present findings, recommend, but let the user choose
 - **Track what ran** — when presenting results, show which Guardians completed and which are pending
-- **Always use `model: "claude-opus-4.6"`** — all Guardian agents must run under Opus 4.6. Never use default (Haiku) for Guardian work.
+- **Always use `model: "claude-opus-4.7"`** — all Guardian agents must run under Opus 4.7. Never use default (Haiku) for Guardian work.

--- a/src/templates/feature-spec.template.md
+++ b/src/templates/feature-spec.template.md
@@ -1,0 +1,342 @@
+<!--
+=============================================================================
+  Feature Spec Template — SDLC Guardian Agents
+=============================================================================
+
+  COMPATIBILITY: Spec Kit (https://github.com/github/spec-kit)
+  -----------------------------------------------------------
+  Sections 1–4 below are MECHANICALLY IDENTICAL to Spec Kit's
+  templates/spec-template.md (source: github/spec-kit, ref:
+  259494a328e13df32e18b2df31abd421c881c071). Heading text, ID format
+  (FR-001, SC-001), user-story structure, and field labels match exactly.
+
+  This means a Spec Kit-aware tool (`/speckit.specify`, `specify`, etc.)
+  can read and process this file as if it were a native Spec Kit spec.
+  The SDLC Guardian extensions in Sections 5–8 use new top-level headings
+  Spec Kit does not consume; tooling will ignore them safely.
+
+  Spec Kit's separate plan.md (Technical Context, Project Structure) is
+  intentionally NOT included here — that ground is covered by the PO
+  Guardian's 18-section ticket and the project's ARCHITECTURE.md. Users
+  who want a parallel Spec Kit plan can run `/speckit.plan` to generate
+  one alongside this file.
+
+  PURPOSE
+  -------
+  Single readable artifact per feature. Aggregates the PO Guardian's
+  research output into a holistic, system-aware view BEFORE decomposition
+  into tickets. The spec is derived from work the PO already does — it
+  reorganizes that output into a format developers, reviewers, and AI
+  agents can consume in one read.
+
+  WHEN TO PRODUCE
+  ---------------
+  PO Guardian decides per request based on complexity. The judgment and
+  rationale MUST be captured in the parent ticket(s) — see the
+  `Parent Spec:` field convention.
+
+    - Produce a Formal Spec when it adds clarity (multi-component changes,
+      cross-Guardian impact, architectural shifts, new product surfaces).
+    - Skip a Formal Spec when ceremony exceeds value (trivial bug fixes,
+      single-file refactors, hotfixes). Record skip rationale in the
+      ticket's `Parent Spec:` field as "N/A — [reason]".
+
+  STORAGE
+  -------
+  Target projects store specs at:    specs/{feature}/spec.md
+  where {feature} is a kebab-case slug derived from the feature name.
+
+  The spec lives in the target project repo (NOT in the SDLC Guardians
+  source repo). Bidirectional links: spec links to the issue tracker;
+  tickets and PRs carry a `Parent Spec:` field referencing this file.
+
+  AUTHORING NOTES
+  ---------------
+  - Every section MUST have content or "N/A — [reason]". Silence is not
+    acceptable. The spec is the holistic surface — gaps here produce gaps
+    in tickets, implementation, and review.
+  - Mark unresolved ambiguity with [NEEDS CLARIFICATION: ...] inline.
+    Open clarifications block decomposition.
+  - Be specific, not vague. "p95 < 200ms" not "fast"; "max 200 chars" not
+    "short". Measurable success criteria are mandatory.
+  - Do not modify Section 1–4 headings or ID formats — Spec Kit
+    compatibility depends on them. Sections 5–8 are SDLC extensions and
+    may evolve independently.
+=============================================================================
+-->
+
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`
+**Created**: [DATE]
+**Status**: Draft
+**Input**: User description: "$ARGUMENTS"
+
+<!--
+  SDLC Guardian extension fields (additive — Spec Kit ignores unknown fields).
+  Populate during PO Step 0 / decomposition.
+-->
+
+**Owner**: [Person or team accountable for the spec]
+**Last updated**: [DATE]
+**Issue tracker**: [Link to parent epic, milestone, or coordinating issue]
+**Tickets**: [List of ticket IDs derived from this spec — populated during decomposition]
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]
+
+<!--
+=============================================================================
+  END OF SPEC KIT-COMPATIBLE CONTENT
+=============================================================================
+  Sections below are SDLC Guardian extensions. They use new top-level (##)
+  headings that Spec Kit tooling does not consume. They MUST be filled out
+  for the SDLC Guardian pipeline (PO decomposition, Guardian reviews,
+  drift detection, archive) but are optional from a Spec Kit perspective.
+=============================================================================
+-->
+
+## Decomposition
+
+> **The ticket tree.** Populated during PO Step 5. Each ticket links back to
+> this spec via its `Parent Spec:` field. The decomposition shows how the
+> holistic feature breaks into independently shippable units.
+
+### Module map
+
+| Module | Purpose | Tickets |
+|--------|---------|---------|
+| [Module name] | [Single responsibility] | [#123, #124] |
+
+### Sequencing and dependencies
+
+> Which tickets must complete before others? What can ship in parallel?
+
+- **Phase A (foundation):** [Tickets]
+- **Phase B (depends on A):** [Tickets]
+- **Phase C (parallel with B):** [Tickets]
+
+### Decomposition rationale
+
+[One paragraph. Why this decomposition? What alternatives were considered? What trade-offs were accepted?]
+
+## Guardian Consultation Results
+
+> **Captured ONCE at the feature level**, not repeated per ticket. Output of
+> PO Step 5b (and Step 5c once Phase 2 of issue #78 lands). Each subsection
+> lists the requirements that domain Guardian raised when consulted.
+
+### Security Guardian
+
+- [Requirement]: [Rationale / OWASP reference]
+- [Requirement]: ...
+
+### Privacy Guardian
+
+- [Requirement]: [Rationale / GDPR/HIPAA/CCPA reference]
+- [Requirement]: ...
+
+### Platform Guardian
+
+- [Requirement]: [Rationale / infra/k8s/networking concern]
+- [Requirement]: ...
+
+### Delivery Guardian
+
+- [Requirement]: [Rationale / deployment/CI/observability concern]
+- [Requirement]: ...
+
+### Code Review Guardian (architectural impact)
+
+> Populated by PO Step 5c — added in Phase 2 of issue #78. Until then,
+> leave as N/A or omit.
+
+- [Architectural concern]: [Rationale]
+
+## System Impact
+
+> **The delta — what changes in the existing system.** Tickets describe new
+> components well; they describe deltas to the existing architecture poorly.
+> This section is mandatory and exists to close that gap.
+
+### Affected components
+
+| Component | Change type | Description |
+|-----------|-------------|-------------|
+| [Existing component] | New / Modified / Deprecated / Removed | [What changes about it] |
+
+### Affected contracts
+
+> APIs, message schemas, database schemas, configuration files, environment
+> variables, CLI flags — anything with a contract surface.
+
+| Contract | Change | Backward compatible? |
+|----------|--------|---------------------|
+| [Contract name] | [Add field / breaking change / deprecate / etc.] | Yes / No — [if no, migration strategy] |
+
+### Architectural deltas
+
+> What assumptions about the system change as a result of this feature?
+
+- [Assumption that no longer holds, or new assumption introduced]
+
+### Backward compatibility and migration
+
+- **Breaking changes:** [List, or "None"]
+- **Migration path:** [How existing users/data/integrations move to the new state]
+- **Deprecation timeline:** [If applicable]
+
+### Risk surface
+
+- **Risks introduced:** [New attack surface, new failure modes, new operational burden]
+- **Risks reduced:** [Existing risks this feature mitigates]
+
+## Product Impact
+
+> **The strategic delta — how this feature shifts the product.** Often
+> implicit in feature requests; making it explicit prevents scope drift and
+> aligns reviewers.
+
+### Positioning shift
+
+[Does this feature change how the product is positioned, marketed, or differentiated? If yes, how?]
+
+### Scope boundary changes
+
+[Does this feature expand or narrow the product's overall scope? Does it open or close a category of future work?]
+
+### Roadmap dependencies
+
+- **Unlocks:** [Future features that become possible because of this one]
+- **Blocks or delays:** [Future features deprioritized or made harder by this one]
+- **Depends on:** [Existing work this feature relies on]
+
+### User-facing communication
+
+- **Internal stakeholders to inform:** [Teams that need a heads-up]
+- **External communication needed:** [Release notes, docs, blog post, customer comms — or "None"]
+
+## Appendix — References
+
+- [Link to research, prior art, related ADRs, design docs]
+- [Link to user research, support tickets, analytics that motivated the feature]
+- [Link to relevant standards or external specifications]

--- a/src/templates/feature-spec.template.md
+++ b/src/templates/feature-spec.template.md
@@ -62,6 +62,15 @@
   - Do not modify Section 1–4 headings or ID formats — Spec Kit
     compatibility depends on them. Sections 5–8 are SDLC extensions and
     may evolve independently.
+
+  VERSIONING
+  ----------
+  Git history is the version log. Update the `Last updated` header field
+  on every change so the latest revision is visible without `git log`,
+  but do NOT maintain a separate amendment log inside the spec — `git log
+  -- specs/{feature}/spec.md` (or `git blame`) is the source of truth for
+  who changed what and when. Keeping a parallel changelog inside the spec
+  body invariably drifts from the git history.
 =============================================================================
 -->
 


### PR DESCRIPTION
## Summary

Implements all 5 phases of issue #78 — Formal Specification as the first SDLC artifact, distributed across existing Guardians (no new Guardian added).

Closes #78.

## What's in this PR

| Phase | Commit | Capability |
|---|---|---|
| 1 | `4985f03` | Spec Kit-compatible Feature Spec template + PO Steps 4b/5c + `Parent Spec:` field |
| 2 | `87c8f7b` | PO Step 2c (brownfield bootstrap), Step 5b-arch (Code Review consult), bug-fix→spec-patch rule |
| 3 | `0a5d2af` | Code Review Guardian Domain 8: drift detection, Parent Spec linkage, bug-fix-PR enforcement, spec hygiene |
| 4 | `1f43869` | Operator Procedure 6: Feature Archive (post-merge digest) |
| 5 | `1b43ae7` | Orchestrator Post-Merge Archive Gate + Pre-Merge spec checks + workflow updates |
| 5b | `f62fcab` | Lock in answers to the 3 deferred open questions |
| extra | `047d751` | Model upgrade: Opus 4.6 → 4.7, GPT 5.4 → 5.5 (newer models available) |

## Key design decisions (recorded in #78)

- **No new Guardian.** All 5 capabilities map onto existing roles (PO owns spec content, Code Review enforces drift, Operator archives).
- **No separate `constitution.md` file.** The instructions layer at `~/.copilot/instructions/` already serves as the executable constitution — duplicating it as markdown would create two sources of truth that drift.
- **Spec Kit compatibility is mechanical, not just conceptual.** Sections 1–4 of the Feature Spec template are byte-for-byte identical to `github/spec-kit` `templates/spec-template.md` (verified against ref `259494a328e13df32e18b2df31abd421c881c071`). SDLC extensions sit on top as new top-level `##` sections that Spec Kit tooling safely ignores.
- **Per-request judgment, not a fixed threshold.** PO Guardian decides whether each piece of work warrants a Formal Spec. Decision and rationale are captured in every ticket via the `Parent Spec:` field.
- **Bugs patch specs.** Bug-fix tickets against an area with a parent spec must update the spec as part of the ticket — bugs are evidence the spec was wrong. Code Review enforces this in Phase 3.
- **Git history is the version log.** No parallel amendment log inside the spec body — `git log -- specs/{feature}/spec.md` is authoritative.
- **Missing `Parent Spec:` is a permanent warning, not a blocking gate.** Code Review flags it 🟡 MEDIUM but does not block merge — the judgment about whether a spec was warranted belongs to the PO and the human reviewer.

## How this PR exercises its own changes

This PR has **no `Parent Spec:` field** — there is no spec for the spec system. Per Phase 3 Domain 8.1, Code Review will flag a 🟡 MEDIUM warning. **This is the expected behavior** and validates the rule.

If you adopt this PR's changes, future PRs will routinely carry `Parent Spec:` fields. This bootstrap PR is the exception.

## Verification

- ✅ `bash -n package.sh` clean
- ✅ All 114 unit tests pass (`node --test src/extensions/sdlc-guardian/uat-state-machine.test.mjs`)
- ✅ `bash package.sh --install` deploys new templates dir cleanly
- ✅ `bash package.sh --uninstall` cleans up templates dir cleanly
- ✅ Spec Kit Sections 1–4 verified mechanically identical to upstream

## Files changed

| File | Change |
|---|---|
| `src/templates/feature-spec.template.md` | NEW — 342 lines, Spec Kit-compatible |
| `src/agents/po-guardian.agent.md` | +121 lines (Steps 2c, 4b, 5b-arch, 5c + bug-fix rule + Parent Spec field) |
| `src/agents/code-review-guardian.agent.md` | +44 lines (Domain 8) + 4 new tags |
| `src/agents/operator.agent.md` | +124 lines (Procedure 6) |
| `src/instructions/po-guardian.instructions.md` | Workflow expanded 7→10 steps |
| `src/instructions/code-review-guardian.instructions.md` | Spec-aware review section + model upgrade |
| `src/instructions/operator.instructions.md` | Archive trigger words + post-merge hook description |
| `src/instructions/sdlc-workflow.instructions.md` | Pre-Merge spec checks + new Post-Merge Archive Gate + workflow diagram + model upgrade |
| `src/extensions/sdlc-guardian/uat-state-machine.mjs` | Model string update |
| `package.sh` | Templates dir install/uninstall + log line |
| `README.md` | Six gates instead of five, workflow diagram extended, file structure includes templates/ |
| `USER-GUIDE.md` | PO Guardian section explains the Formal Spec decision |

## Out of scope (recorded in #78)

- Full Spec Kit CLI integration (`specify init`, `/speckit.*` slash commands)
- Publishing SDLC Guardians as a Spec Kit community extension
- Automated spec linting (validating spec well-formedness)
- A dedicated `constitution.md` file (rejected — instructions layer is the constitution)

## Co-authored

Built collaboratively with Copilot CLI in a long pair-programming session — no Guardian-on-Guardian recursion (the user explicitly preferred to write the Guardian system by hand).
